### PR TITLE
Do not send 'transport=tls' in the SIP request line.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/sip/SipRegistrarConnection.java
+++ b/src/net/java/sip/communicator/impl/protocol/sip/SipRegistrarConnection.java
@@ -186,7 +186,7 @@ public class SipRegistrarConnection
         this.sipProvider = sipProviderCallback;
 
         //init expiration timeout
-        this.registrationsExpiration = 
+        this.registrationsExpiration =
             SipActivator.getConfigurationService().getInt(
                 REGISTRATION_EXPIRATION,
                 DEFAULT_REGISTRATION_EXPIRATION);
@@ -1209,7 +1209,8 @@ public class SipRegistrarConnection
             if(registrarPort != ListeningPoint.PORT_5060)
                 registrarURI.setPort(registrarPort);
 
-            if(!registrationTransport.equals(ListeningPoint.UDP))
+            if(!(registrationTransport.equals(ListeningPoint.UDP) ||
+                (registrationTransport.equals(ListeningPoint.TLS))))
                 registrarURI.setTransportParam(registrationTransport);
         }
         return registrarURI;


### PR DESCRIPTION
Existing code sends SIP TLS requests that begin like:
REGISTER sip:<URI>;transport=tls SIP/2.0

This is bad behaviour because it specifies that TLS should be used for each hop in the network, but TLS should only be defined hop-to-hop.

We came across this problem because our SBC respected this option in the SIP REGISTER requests, and passed this on to our SIP server. We don't use TLS on the core side of our SBC so this failed with a 400 response from the server.

This change removes the 'transport=tls' option so the request would look like:
REGISTER sip:<URI> SIP/2.0

The change does not modify the contact or via headers in the SIP messages, just the request line.