### PR TITLE
Compare OTR fingerprints case insensitively

### DIFF
--- a/src/net/java/sip/communicator/plugin/otr/OtrBuddyAuthenticationDialog.java
+++ b/src/net/java/sip/communicator/plugin/otr/OtrBuddyAuthenticationDialog.java
@@ -299,8 +299,8 @@ public class OtrBuddyAuthenticationDialog
             txtRemoteFingerprintComparison.setBackground(Color.white);
             return;
         }
-        if(txtRemoteFingerprintComparison.getText().contains(
-            OtrActivator.scOtrKeyManager.getRemoteFingerprint(contact)))
+        if(txtRemoteFingerprintComparison.getText().toLowerCase().contains(
+            OtrActivator.scOtrKeyManager.getRemoteFingerprint(contact).toLowerCase()))
         {
             txtRemoteFingerprintComparison.setBackground(Color.green);
             cbAction.setSelectedItem(actionIHave);


### PR DESCRIPTION
OTR fingerprints are hex and therefore are case insensitive, so compare them as such.  In particular, Adium uses lower case and Jitsi use upper case.
