### PR TITLE
Trim the contact address before adding it

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/main/contactlist/AddContactDialog.java
+++ b/src/net/java/sip/communicator/impl/gui/main/contactlist/AddContactDialog.java
@@ -374,7 +374,7 @@ public class AddContactDialog
         {
             final ProtocolProviderService protocolProvider
                 = (ProtocolProviderService) accountCombo.getSelectedItem();
-            final String contactAddress = contactAddressField.getText();
+            final String contactAddress = contactAddressField.getText().trim();
             final String displayName = displayNameField.getText();
 
             if (!protocolProvider.isRegistered())


### PR DESCRIPTION
Because:
* Technically: addresses with spaces don't exist
* Functionally: a user may add an address with a space in it and wait for an
authorization that would never come