### PR TITLE
Fix isPrivate check in case only one user is in the room.

### DIFF
--- a/src/net/java/sip/communicator/service/muc/MUCService.java
+++ b/src/net/java/sip/communicator/service/muc/MUCService.java
@@ -229,8 +229,8 @@ public abstract class MUCService
             {
                 for (ChatRoomMember member : chatRoom.getMembers())
                     if (nickname.equals(member.getName()))
-                        return false;
-                return true;
+                        return true;
+                return false;
             }
         }
         return false;


### PR DESCRIPTION
I believe some return values might be swapped, but as always, correct me if I'm wrong. CC'ed Hristo, I believe he might be familiar with this due to the recent MUC UI changes.

I am loading a chatroom with 1 user (other than myself) and it shows up without a contact list. Tracing through the code I reach a method 'ConferenceChatSession: boolean isContactListSupported()'. I believe
this is the point where is being determined whether or not to show this column with chat room members.

MUCService.isPrivate(chatroom) is used to determine whether or not the chatroom is "private".
The current implementation of this claims that:
- if there is one chat room member and the local user is it, then it is not a private room,
- while if there's one user and it's someone else, the room is private.

So ... the return values are swapped(?)
