### PR TITLE
Spellcheck plugin: Locales now define their flag icon in the XML file.

### DIFF
--- a/resources/config/spellcheck/parameters.xml
+++ b/resources/config/spellcheck/parameters.xml
@@ -12,6 +12,7 @@
   <!ATTLIST locale label CDATA #REQUIRED>
   <!ATTLIST locale isoCode CDATA #REQUIRED>
   <!ATTLIST locale dictionaryUrl CDATA #REQUIRED>
+  <!ATTLIST locale flagIcon CDATA #REQUIRED>
 ]>
 
 <spellCheckerParameters>
@@ -46,98 +47,98 @@
 
         Some missing dictionaries:
 
-        <locale label="Khmer (Cambodia)" isoCode="km,kh" dictionaryUrl=""/>
-        <locale label="Oriya (India)" isoCode="or,in" dictionaryUrl="or_IN.zip"/>
-        <locale label="Uzbek (Uzbekistan)" isoCode="uz,uz" dictionaryUrl="uz_UZ.zip"/>
-        <locale label="Latin" isoCode="la,va" dictionaryUrl="http://www.drouizig.org/oo/la_VA.zip"/>
+        <locale label="Khmer (Cambodia)" isoCode="km,kh" dictionaryUrl="" flagIcon="kh"/>
+        <locale label="Oriya (India)" isoCode="or,in" dictionaryUrl="or_IN.zip" flagIcon="in"/>
+        <locale label="Uzbek (Uzbekistan)" isoCode="uz,uz" dictionaryUrl="uz_UZ.zip" flagIcon="uz"/>
+        <locale label="Latin" isoCode="la,va" dictionaryUrl="http://www.drouizig.org/oo/la_VA.zip" flagIcon="va"/>
     -->
     
     <!--
       The following failed to be processed by the spellchecker API (probably due to hunspell formatting).
-    <locale label="Arabic (North Africa and Middle East)" isoCode="ar,xx" dictionaryUrl="http://downloads.sourceforge.net/ayaspell/hunspell-ar_20080110.tar.gz"/>
-    <locale label="Chichewa (Malawi)" isoCode="ny,mw" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/ny_MW.zip"/>
-    <locale label="Coptic (North Africa)" isoCode="xx,xx" dictionaryUrl="http://www.moheb.de/download/cop_EG_v0.2.tgz"/>
-    <locale label="Finnish (Finland)" isoCode="fi,fi" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/fi_FI.zip"/>
-    <locale label="French (Belgium)" isoCode="fr,be" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/fr_BE.zip"/>
-    <locale label="Gascon (France)" isoCode="xx,fr" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/gsc_FR.zip"/>
-    <locale label="Greek (Greece)" isoCode="el,gr" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/el_GR.zip"/>
-    <locale label="Hungarian (Hungary)" isoCode="hu,hu" dictionaryUrl="http://downloads.sourceforge.net/magyarispell/hu_HU-1.3.tar.gz"/>
-    <locale label="Icelandic (Iceland)" isoCode="is,is" dictionaryUrl="http://hunspell.sourceforge.net/is_IS.zip"/>
-    <locale label="Māori (Aotearoa)" isoCode="mi,xx" dictionaryUrl="http://packages.papakupu.maori.nz/hunspell/hunspell-mi-latest_beta.tar.gz"/>
-    <locale label="Quechua (Bolivia)" isoCode="qu,bo" dictionaryUrl="http://hunspell.sourceforge.net/qu_BO-pack.zip"/>
-    <locale label="Thai (Thailand)" isoCode="th,th" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/th_TH.zip"/>
-    <locale label="Urdu (Pakistan)" isoCode="ur,pk" dictionaryUrl="http://ftp.stardiv.de/pub/OpenOffice.org/contrib/dictionaries/ur_PK.zip"/>
-    <locale label="Wayunaiki, Experimental (Venezuela)" isoCode="xx,ve" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/??_VE.zip"/>
-    <locale label="Welsh (Wales)" isoCode="cy,gb" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/cy_GB.zip"/>
-    <locale label="Northern Sami" isoCode="xx,xx" dictionaryUrl="http://divvun.no/static_files/se.zip"/>
+    <locale label="Arabic (North Africa and Middle East)" isoCode="ar,xx" dictionaryUrl="http://downloads.sourceforge.net/ayaspell/hunspell-ar_20080110.tar.gz" flagIcon="xx"/>
+    <locale label="Chichewa (Malawi)" isoCode="ny,mw" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/ny_MW.zip" flagIcon="mw"/>
+    <locale label="Coptic (North Africa)" isoCode="xx,xx" dictionaryUrl="http://www.moheb.de/download/cop_EG_v0.2.tgz" flagIcon="xx"/>
+    <locale label="Finnish (Finland)" isoCode="fi,fi" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/fi_FI.zip" flagIcon="fi"/>
+    <locale label="French (Belgium)" isoCode="fr,be" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/fr_BE.zip" flagIcon="be"/>
+    <locale label="Gascon (France)" isoCode="xx,fr" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/gsc_FR.zip" flagIcon="fr"/>
+    <locale label="Greek (Greece)" isoCode="el,gr" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/el_GR.zip" flagIcon="gr"/>
+    <locale label="Hungarian (Hungary)" isoCode="hu,hu" dictionaryUrl="http://downloads.sourceforge.net/magyarispell/hu_HU-1.3.tar.gz" flagIcon="hu"/>
+    <locale label="Icelandic (Iceland)" isoCode="is,is" dictionaryUrl="http://hunspell.sourceforge.net/is_IS.zip" flagIcon="is"/>
+    <locale label="Māori (Aotearoa)" isoCode="mi,xx" dictionaryUrl="http://packages.papakupu.maori.nz/hunspell/hunspell-mi-latest_beta.tar.gz" flagIcon="xx"/>
+    <locale label="Quechua (Bolivia)" isoCode="qu,bo" dictionaryUrl="http://hunspell.sourceforge.net/qu_BO-pack.zip" flagIcon="bo"/>
+    <locale label="Thai (Thailand)" isoCode="th,th" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/th_TH.zip" flagIcon="th"/>
+    <locale label="Urdu (Pakistan)" isoCode="ur,pk" dictionaryUrl="http://ftp.stardiv.de/pub/OpenOffice.org/contrib/dictionaries/ur_PK.zip" flagIcon="pk"/>
+    <locale label="Wayunaiki, Experimental (Venezuela)" isoCode="xx,ve" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/??_VE.zip"  flagIcon="ve"/>
+    <locale label="Welsh (Wales)" isoCode="cy,gb" dictionaryUrl="http://ftp.services.openoffice.org/pub/OpenOffice.org/contrib/dictionaries/cy_GB.zip" flagIcon="wales"/>
+    <locale label="Northern Sami" isoCode="xx,xx" dictionaryUrl="http://divvun.no/static_files/se.zip"  flagIcon="xx"/>
     -->
 
-    <locale label="Afrikaans (South Africa)" isoCode="af,za" dictionaryUrl="http://dictionaries.jitsi.net/af_ZA.zip"/>
-    <locale label="Armenian (Eastern and Western)" isoCode="hy,xx" dictionaryUrl="http://dictionaries.jitsi.net/hy_xx.zip"/>
-    <locale label="Basque" isoCode="eu,xx" dictionaryUrl="http://dictionaries.jitsi.net/eu-ES-hunspell.zip"/>
-    <locale label="Bulgarian (Bulgaria)" isoCode="bg,bg" dictionaryUrl="http://dictionaries.jitsi.net/bg_BG.zip"/>
-    <locale label="Catalan" isoCode="ca,es" dictionaryUrl="http://dictionaries.jitsi.net/ca_ES.zip"/>
-    <locale label="Croatian (Croatia)" isoCode="hr,hr" dictionaryUrl="http://dictionaries.jitsi.net/hr_HR.zip"/>
-    <locale label="Czech (Czech Republic)" isoCode="cs,cz" dictionaryUrl="http://dictionaries.jitsi.net/cs_CZ.zip"/>
-    <locale label="Dutch (Netherlands)" isoCode="nl,nl" dictionaryUrl="http://dictionaries.jitsi.net/nl_NL.zip"/>
-    <locale label="English (United Kingdom)" isoCode="en,gb" dictionaryUrl="http://dictionaries.jitsi.net/en_GB.zip"/>
-    <locale label="English (United States)" isoCode="en,us" dictionaryUrl="http://dictionaries.jitsi.net/en_US.zip"/>
-    <locale label="English (Australia)" isoCode="en,au" dictionaryUrl="http://dictionaries.jitsi.net/en_AU.zip"/>
-    <locale label="English (Canada)" isoCode="en,ca" dictionaryUrl="http://dictionaries.jitsi.net/en_CA.zip"/>
-    <locale label="English (New Zealand)" isoCode="en,nz" dictionaryUrl="http://dictionaries.jitsi.net/en_NZ.zip"/>
-    <locale label="English (South Africa)" isoCode="en,za" dictionaryUrl="http://dictionaries.jitsi.net/en_ZA.zip"/>
-    <locale label="Esperanto" isoCode="eo,xx" dictionaryUrl="http://dictionaries.jitsi.net/eo.zip"/>
-    <locale label="Faroese (Faroe Islands)" isoCode="fo,fo" dictionaryUrl="http://dictionaries.jitsi.net/fo_FO.zip"/>
-    <locale label="French (France)" isoCode="fr,fr" dictionaryUrl="http://dictionaries.jitsi.org/fr_FR.zip"/>
-    <locale label="Frisian (Netherlands)" isoCode="fy,nl" dictionaryUrl="http://dictionaries.jitsi.net/fy_NL.zip"/>
-    <locale label="Galician (Spain)" isoCode="gl,es" dictionaryUrl="http://dictionaries.jitsi.net/gl_ES.zip"/>
-    <locale label="German (Germany)" isoCode="de,de" dictionaryUrl="http://dictionaries.jitsi.net/de_DE_frami.zip"/>
-    <locale label="Greek (Greece)" isoCode="el,gr" dictionaryUrl="http://dictionaries.jitsi.net/el_gr_v110.zip"/>
-    <locale label="Hebrew (Israel)" isoCode="he,il" dictionaryUrl="http://dictionaries.jitsi.net/he_IL.zip"/>
-    <locale label="Hindi (India)" isoCode="hi,in" dictionaryUrl="http://dictionaries.jitsi.net/hi_IN.zip"/>
-    <locale label="Indonesian (Indonesia)" isoCode="id,id" dictionaryUrl="http://dictionaries.jitsi.net/id_ID.zip"/>
-    <locale label="Interlingua" isoCode="ia,xx" dictionaryUrl="http://dictionaries.jitsi.net/ia_myspell.zip"/>
-    <locale label="Irish (Ireland)" isoCode="ga,ie" dictionaryUrl="http://dictionaries.jitsi.net/ga_IE.zip"/>
-    <locale label="Italian (Italy)" isoCode="it,it" dictionaryUrl="http://dictionaries.jitsi.net/it_IT.zip"/>
-    <locale label="Kinyarwanda (Rwanda)" isoCode="rw,rw" dictionaryUrl="http://dictionaries.jitsi.net/rw_RW.zip"/>
-    <locale label="Kurdish (Turkey, Syria, Iran, Iraq)" isoCode="ku,tr" dictionaryUrl="http://dictionaries.jitsi.net/ku_TR.zip"/>
-    <locale label="Kiswahili (East Africa)" isoCode="xx,xx" dictionaryUrl="http://dictionaries.jitsi.net/xx_XX.zip"/>
-    <locale label="Latvian (Latvia)" isoCode="lv,lv" dictionaryUrl="http://dictionaries.jitsi.net/lv_LV.zip"/>
-    <locale label="Lithuanian (Lithuania)" isoCode="lt,lt" dictionaryUrl="http://dictionaries.jitsi.net/lt_LT.zip"/>
-    <locale label="Malagasy (Madagascar)" isoCode="mg,mg" dictionaryUrl="http://dictionaries.jitsi.net/mg_MG.zip"/>
-    <locale label="Malay (Malaysia)" isoCode="ms,my" dictionaryUrl="http://dictionaries.jitsi.net/ms_MY.zip"/>
-    <locale label="Marathi (India)" isoCode="mr,in" dictionaryUrl="http://dictionaries.jitsi.net/mr_IN.zip"/>
-    <locale label="Mongolian (Mongolia)" isoCode="mn,mn" dictionaryUrl="http://dictionaries.jitsi.net/mn_MN.zip"/>
-    <locale label="Ndebele (South Africa)" isoCode="nr,za" dictionaryUrl="http://dictionaries.jitsi.net/nr_ZA.zip"/>
-    <locale label="Nepali (Nepal)" isoCode="ne,np" dictionaryUrl="http://dictionaries.jitsi.net/ne_NP_dict.zip"/>
-    <locale label="Northern Sotho (South Africa)" isoCode="ns,za" dictionaryUrl="http://dictionaries.jitsi.net/ns_ZA.zip"/>
-    <locale label="Norwegian (Norway)" isoCode="nb,no" dictionaryUrl="http://dictionaries.jitsi.net/nb_NO.zip"/>
-    <locale label="Norwegian, Nynorsk (Norway)" isoCode="nn,no" dictionaryUrl="http://dictionaries.jitsi.net/nn_NO.zip"/>
-    <locale label="Occitan (France)" isoCode="oc,fr" dictionaryUrl="http://dictionaries.jitsi.net/oc_FR.zip"/>
-    <locale label="Persian (Iran)" isoCode="fa,ir" dictionaryUrl="http://dictionaries.jitsi.net/fa_IR.zip"/>
-    <locale label="Polish (Poland)" isoCode="pl,pl" dictionaryUrl="http://dictionaries.jitsi.net/pl_PL.zip"/>
-    <locale label="Portuguese (Portugal)" isoCode="pt,pt" dictionaryUrl="http://dictionaries.jitsi.net/pt_PT.zip"/>
-    <locale label="Punjabi (India)" isoCode="xx,in" dictionaryUrl="http://dictionaries.jitsi.net/xx_IN.zip"/>
-    <locale label="Romanian (Romania)" isoCode="ro,ro" dictionaryUrl="http://dictionaries.jitsi.net/ro_RO.zip"/>
-    <locale label="Russian (Russia)" isoCode="ru,ru" dictionaryUrl="http://dictionaries.jitsi.net/ru_RU.zip"/>
-    <locale label="Scottish Gaelic (Scotland)" isoCode="gd,gb" dictionaryUrl="http://dictionaries.jitsi.net/gd_GB.zip"/>
-    <locale label="Setswana (Africa)" isoCode="tn,za" dictionaryUrl="http://dictionaries.jitsi.net/tn_ZA.zip"/>
-    <locale label="Slovak (Slovakia)" isoCode="sk,sk" dictionaryUrl="http://dictionaries.jitsi.net/myspell-sk_SK-0.5.6.zip"/>
-    <locale label="Slovenian (Slovenia)" isoCode="sl,sl" dictionaryUrl="http://dictionaries.jitsi.net/sl_SI.zip"/>
-    <locale label="Southern Sotho (South Africa)" isoCode="st,za" dictionaryUrl="http://dictionaries.jitsi.net/st_ZA.zip"/>
-    <locale label="Spanish (Spain)" isoCode="es,es" dictionaryUrl="http://dictionaries.jitsi.net/es_ES.zip"/>
-    <locale label="Spanish (Mexico)" isoCode="es,mx" dictionaryUrl="http://dictionaries.jitsi.net/es_MX.zip"/>
-    <locale label="Swazi/Swati (South Africa)" isoCode="ss,za" dictionaryUrl="http://dictionaries.jitsi.net/ss_ZA.zip"/>
-    <locale label="Swedish (Sweden)" isoCode="sv,se" dictionaryUrl="http://dictionaries.jitsi.net/sv_SE.zip"/>
-    <locale label="Tagalog (Philippines)" isoCode="tl,ph" dictionaryUrl="http://dictionaries.jitsi.net/tl_PH.zip"/>
-    <locale label="Tamil (India)" isoCode="ta,in" dictionaryUrl="http://dictionaries.jitsi.net/ta_IN.zip"/>
-    <locale label="Tetum (Indonesia)" isoCode="xx,id" dictionaryUrl="http://dictionaries.jitsi.net/tet_ID.zip"/>
-    <locale label="Tsonga (South Africa)" isoCode="ts,za" dictionaryUrl="http://dictionaries.jitsi.net/ts_ZA.zip"/>
-    <locale label="Ukrainian (Ukraine)" isoCode="uk,ua" dictionaryUrl="http://dictionaries.jitsi.net/uk_UA.zip"/>
-    <locale label="Venda (South Africa)" isoCode="ve,za" dictionaryUrl="http://dictionaries.jitsi.net/ve_ZA.zip"/>
-    <locale label="Vietnamese (Vietnam)" isoCode="vi,vn" dictionaryUrl="http://dictionaries.jitsi.net/vi_VN.zip"/>
-    <locale label="Xhosa (South Africa)" isoCode="xh,za" dictionaryUrl="http://dictionaries.jitsi.net/xh_ZA.zip"/>
-    <locale label="Zulu (Africa)" isoCode="zu,za" dictionaryUrl="http://dictionaries.jitsi.net/zu_ZA.zip"/>
+    <locale label="Afrikaans (South Africa)" isoCode="af,za" dictionaryUrl="http://dictionaries.jitsi.net/af_ZA.zip" flagIcon="za"/>
+    <locale label="Armenian (Eastern and Western)" isoCode="hy,am" dictionaryUrl="http://dictionaries.jitsi.net/hy_xx.zip" flagIcon="am"/>
+    <locale label="Basque" isoCode="eu,xx" dictionaryUrl="http://dictionaries.jitsi.net/eu-ES-hunspell.zip" flagIcon="xx"/>
+    <locale label="Bulgarian (Bulgaria)" isoCode="bg,bg" dictionaryUrl="http://dictionaries.jitsi.net/bg_BG.zip" flagIcon="bg"/>
+    <locale label="Catalan" isoCode="ca,es" dictionaryUrl="http://dictionaries.jitsi.net/ca_ES.zip" flagIcon="catalonia"/>
+    <locale label="Croatian (Croatia)" isoCode="hr,hr" dictionaryUrl="http://dictionaries.jitsi.net/hr_HR.zip" flagIcon="hr"/>
+    <locale label="Czech (Czech Republic)" isoCode="cs,cz" dictionaryUrl="http://dictionaries.jitsi.net/cs_CZ.zip" flagIcon="cz"/>
+    <locale label="Dutch (Netherlands)" isoCode="nl,nl" dictionaryUrl="http://dictionaries.jitsi.net/nl_NL.zip" flagIcon="nl"/>
+    <locale label="English (United Kingdom)" isoCode="en,gb" dictionaryUrl="http://dictionaries.jitsi.net/en_GB.zip" flagIcon="gb"/>
+    <locale label="English (United States)" isoCode="en,us" dictionaryUrl="http://dictionaries.jitsi.net/en_US.zip" flagIcon="us"/>
+    <locale label="English (Australia)" isoCode="en,au" dictionaryUrl="http://dictionaries.jitsi.net/en_AU.zip" flagIcon="au"/>
+    <locale label="English (Canada)" isoCode="en,ca" dictionaryUrl="http://dictionaries.jitsi.net/en_CA.zip" flagIcon="ca"/>
+    <locale label="English (New Zealand)" isoCode="en,nz" dictionaryUrl="http://dictionaries.jitsi.net/en_NZ.zip" flagIcon="nz"/>
+    <locale label="English (South Africa)" isoCode="en,za" dictionaryUrl="http://dictionaries.jitsi.net/en_ZA.zip" flagIcon="za"/>
+    <locale label="Esperanto" isoCode="eo,xx" dictionaryUrl="http://dictionaries.jitsi.net/eo.zip" flagIcon="xx"/>
+    <locale label="Faroese (Faroe Islands)" isoCode="fo,fo" dictionaryUrl="http://dictionaries.jitsi.net/fo_FO.zip" flagIcon="fo"/>
+    <locale label="French (France)" isoCode="fr,fr" dictionaryUrl="http://dictionaries.jitsi.org/fr_FR.zip" flagIcon="fr"/>
+    <locale label="Frisian (Netherlands)" isoCode="fy,nl" dictionaryUrl="http://dictionaries.jitsi.net/fy_NL.zip" flagIcon="nl"/>
+    <locale label="Galician (Spain)" isoCode="gl,es" dictionaryUrl="http://dictionaries.jitsi.net/gl_ES.zip" flagIcon="xx"/>
+    <locale label="German (Germany)" isoCode="de,de" dictionaryUrl="http://dictionaries.jitsi.net/de_DE_frami.zip" flagIcon="de"/>
+    <locale label="Greek (Greece)" isoCode="el,gr" dictionaryUrl="http://dictionaries.jitsi.net/el_gr_v110.zip" flagIcon="gr"/>
+    <locale label="Hebrew (Israel)" isoCode="he,il" dictionaryUrl="http://dictionaries.jitsi.net/he_IL.zip" flagIcon="il"/>
+    <locale label="Hindi (India)" isoCode="hi,in" dictionaryUrl="http://dictionaries.jitsi.net/hi_IN.zip" flagIcon="in"/>
+    <locale label="Indonesian (Indonesia)" isoCode="id,id" dictionaryUrl="http://dictionaries.jitsi.net/id_ID.zip" flagIcon="id"/>
+    <locale label="Interlingua" isoCode="ia,xx" dictionaryUrl="http://dictionaries.jitsi.net/ia_myspell.zip" flagIcon="xx"/>
+    <locale label="Irish (Ireland)" isoCode="ga,ie" dictionaryUrl="http://dictionaries.jitsi.net/ga_IE.zip" flagIcon="ie"/>
+    <locale label="Italian (Italy)" isoCode="it,it" dictionaryUrl="http://dictionaries.jitsi.net/it_IT.zip" flagIcon="it"/>
+    <locale label="Kinyarwanda (Rwanda)" isoCode="rw,rw" dictionaryUrl="http://dictionaries.jitsi.net/rw_RW.zip" flagIcon="rw"/>
+    <locale label="Kurdish (Turkey, Syria, Iran, Iraq)" isoCode="ku,tr" dictionaryUrl="http://dictionaries.jitsi.net/ku_TR.zip" flagIcon="xx"/>
+    <locale label="Kiswahili (East Africa)" isoCode="xx,xx" dictionaryUrl="http://dictionaries.jitsi.net/xx_XX.zip" flagIcon="xx"/>
+    <locale label="Latvian (Latvia)" isoCode="lv,lv" dictionaryUrl="http://dictionaries.jitsi.net/lv_LV.zip" flagIcon="lv"/>
+    <locale label="Lithuanian (Lithuania)" isoCode="lt,lt" dictionaryUrl="http://dictionaries.jitsi.net/lt_LT.zip" flagIcon="lt"/>
+    <locale label="Malagasy (Madagascar)" isoCode="mg,mg" dictionaryUrl="http://dictionaries.jitsi.net/mg_MG.zip" flagIcon="mg"/>
+    <locale label="Malay (Malaysia)" isoCode="ms,my" dictionaryUrl="http://dictionaries.jitsi.net/ms_MY.zip" flagIcon="my"/>
+    <locale label="Marathi (India)" isoCode="mr,in" dictionaryUrl="http://dictionaries.jitsi.net/mr_IN.zip" flagIcon="in"/>
+    <locale label="Mongolian (Mongolia)" isoCode="mn,mn" dictionaryUrl="http://dictionaries.jitsi.net/mn_MN.zip" flagIcon="mn"/>
+    <locale label="Ndebele (South Africa)" isoCode="nr,za" dictionaryUrl="http://dictionaries.jitsi.net/nr_ZA.zip" flagIcon="za"/>
+    <locale label="Nepali (Nepal)" isoCode="ne,np" dictionaryUrl="http://dictionaries.jitsi.net/ne_NP_dict.zip" flagIcon="np"/>
+    <locale label="Northern Sotho (South Africa)" isoCode="ns,za" dictionaryUrl="http://dictionaries.jitsi.net/ns_ZA.zip" flagIcon="za"/>
+    <locale label="Norwegian (Norway)" isoCode="nb,no" dictionaryUrl="http://dictionaries.jitsi.net/nb_NO.zip" flagIcon="no"/>
+    <locale label="Norwegian, Nynorsk (Norway)" isoCode="nn,no" dictionaryUrl="http://dictionaries.jitsi.net/nn_NO.zip" flagIcon="no"/>
+    <locale label="Occitan (France)" isoCode="oc,fr" dictionaryUrl="http://dictionaries.jitsi.net/oc_FR.zip" flagIcon="fr"/>
+    <locale label="Persian (Iran)" isoCode="fa,ir" dictionaryUrl="http://dictionaries.jitsi.net/fa_IR.zip" flagIcon="ir"/>
+    <locale label="Polish (Poland)" isoCode="pl,pl" dictionaryUrl="http://dictionaries.jitsi.net/pl_PL.zip" flagIcon="pl"/>
+    <locale label="Portuguese (Portugal)" isoCode="pt,pt" dictionaryUrl="http://dictionaries.jitsi.net/pt_PT.zip" flagIcon="pt"/>
+    <locale label="Punjabi (India)" isoCode="xx,in" dictionaryUrl="http://dictionaries.jitsi.net/xx_IN.zip" flagIcon="in"/>
+    <locale label="Romanian (Romania)" isoCode="ro,ro" dictionaryUrl="http://dictionaries.jitsi.net/ro_RO.zip" flagIcon="ro"/>
+    <locale label="Russian (Russia)" isoCode="ru,ru" dictionaryUrl="http://dictionaries.jitsi.net/ru_RU.zip" flagIcon="ru"/>
+    <locale label="Scottish Gaelic (Scotland)" isoCode="gd,gb" dictionaryUrl="http://dictionaries.jitsi.net/gd_GB.zip" flagIcon="scotland"/>
+    <locale label="Setswana (Africa)" isoCode="tn,za" dictionaryUrl="http://dictionaries.jitsi.net/tn_ZA.zip" flagIcon="za"/>
+    <locale label="Slovak (Slovakia)" isoCode="sk,sk" dictionaryUrl="http://dictionaries.jitsi.net/myspell-sk_SK-0.5.6.zip" flagIcon="sk"/>
+    <locale label="Slovenian (Slovenia)" isoCode="sl,sl" dictionaryUrl="http://dictionaries.jitsi.net/sl_SI.zip" flagIcon="sl"/>
+    <locale label="Southern Sotho (South Africa)" isoCode="st,za" dictionaryUrl="http://dictionaries.jitsi.net/st_ZA.zip" flagIcon="za"/>
+    <locale label="Spanish (Spain)" isoCode="es,es" dictionaryUrl="http://dictionaries.jitsi.net/es_ES.zip" flagIcon="es"/>
+    <locale label="Spanish (Mexico)" isoCode="es,mx" dictionaryUrl="http://dictionaries.jitsi.net/es_MX.zip" flagIcon="mx"/>
+    <locale label="Swazi/Swati (South Africa)" isoCode="ss,za" dictionaryUrl="http://dictionaries.jitsi.net/ss_ZA.zip" flagIcon="za"/>
+    <locale label="Swedish (Sweden)" isoCode="sv,se" dictionaryUrl="http://dictionaries.jitsi.net/sv_SE.zip" flagIcon="se"/>
+    <locale label="Tagalog (Philippines)" isoCode="tl,ph" dictionaryUrl="http://dictionaries.jitsi.net/tl_PH.zip" flagIcon="ph"/>
+    <locale label="Tamil (India)" isoCode="ta,in" dictionaryUrl="http://dictionaries.jitsi.net/ta_IN.zip" flagIcon="in"/>
+    <locale label="Tetum (Indonesia)" isoCode="xx,id" dictionaryUrl="http://dictionaries.jitsi.net/tet_ID.zip" flagIcon="id"/>
+    <locale label="Tsonga (South Africa)" isoCode="ts,za" dictionaryUrl="http://dictionaries.jitsi.net/ts_ZA.zip" flagIcon="za"/>
+    <locale label="Ukrainian (Ukraine)" isoCode="uk,ua" dictionaryUrl="http://dictionaries.jitsi.net/uk_UA.zip" flagIcon="ua"/>
+    <locale label="Venda (South Africa)" isoCode="ve,za" dictionaryUrl="http://dictionaries.jitsi.net/ve_ZA.zip" flagIcon="za"/>
+    <locale label="Vietnamese (Vietnam)" isoCode="vi,vn" dictionaryUrl="http://dictionaries.jitsi.net/vi_VN.zip" flagIcon="vn"/>
+    <locale label="Xhosa (South Africa)" isoCode="xh,za" dictionaryUrl="http://dictionaries.jitsi.net/xh_ZA.zip" flagIcon="za"/>
+    <locale label="Zulu (Africa)" isoCode="zu,za" dictionaryUrl="http://dictionaries.jitsi.net/zu_ZA.zip" flagIcon="za"/>
   </locales>
 </spellCheckerParameters>
 

--- a/src/net/java/sip/communicator/plugin/spellcheck/LanguageMenuBar.java
+++ b/src/net/java/sip/communicator/plugin/spellcheck/LanguageMenuBar.java
@@ -281,10 +281,7 @@ public class LanguageMenuBar
 
             try
             {
-                int commaIndex = locale.getIsoCode().indexOf(",");
-                String countryCode =
-                    locale.getIsoCode().substring(commaIndex + 1);
-                localeFlag = Resources.getFlagImage(countryCode);
+                localeFlag = Resources.getFlagImage(locale.getFlagIcon());
 
                 BufferedImage flagBuffer = copy(localeFlag.getImage());
                 setFaded(flagBuffer);

--- a/src/net/java/sip/communicator/plugin/spellcheck/Parameters.java
+++ b/src/net/java/sip/communicator/plugin/spellcheck/Parameters.java
@@ -145,9 +145,11 @@ class Parameters
                 ((Attr) attributes.getNamedItem("isoCode")).getValue();
             String dictLocation =
                 ((Attr) attributes.getNamedItem("dictionaryUrl")).getValue();
+            String flagIcon =
+                ((Attr) attributes.getNamedItem("flagIcon")).getValue();
             try
             {
-                LOCALES.add(new Locale(label, code, new URL(dictLocation)));
+                LOCALES.add(new Locale(label, code, new URL(dictLocation), flagIcon));
             }
             catch (MalformedURLException exc)
             {
@@ -206,13 +208,16 @@ class Parameters
 
         private final URL dictLocation;
 
+        private final String flagIcon;
+
         private boolean isLoading = false;
 
-        private Locale(String label, String isoCode, URL dictLocation)
+        private Locale(String label, String isoCode, URL dictLocation, String flagIcon)
         {
             this.label = label;
             this.isoCode = isoCode;
             this.dictLocation = dictLocation;
+            this.flagIcon = flagIcon;
         }
 
         /**
@@ -258,6 +263,17 @@ class Parameters
         public URL getDictUrl()
         {
             return this.dictLocation;
+        }
+
+        /**
+         * Provides the file name of the image files used for the locale's flag,
+         * without file extension of path.
+         *
+         * @return flagIcon of dictionary resource
+         */
+        public String getFlagIcon()
+        {
+            return this.flagIcon;
         }
 
         /**


### PR DESCRIPTION
Could somebody please compile, then open a chat and confirm that the Scottish Gaelic spellchecker comes up with the Scottish flag?

Eclipse/Ant decided to stop recognizing all the inputs after I did some final edits in the XML (!) file and I have already spent more time on the build environment then the actual coding, so your help would be greatly appreciated.
