### PR TITLE
Only create the chat room if provider cannot find it.

### DIFF
--- a/src/net/java/sip/communicator/impl/muc/MUCServiceImpl.java
+++ b/src/net/java/sip/communicator/impl/muc/MUCServiceImpl.java
@@ -398,12 +398,17 @@ public class MUCServiceImpl
         ChatRoom chatRoom = null;
         try
         {
-
-
-            HashMap<String, Object> roomProperties =
-                new HashMap<String, Object>();
-            roomProperties.put("isPrivate", isPrivate);
-            chatRoom = groupChatOpSet.createChatRoom(roomName, roomProperties);
+            chatRoom = groupChatOpSet.findRoom(roomName);
+            if (chatRoom == null)
+            {
+                // The chat room is not known by the MUC provider. Also create
+                // the chat room for the wrapper.
+                HashMap<String, Object> roomProperties =
+                    new HashMap<String, Object>();
+                roomProperties.put("isPrivate", isPrivate);
+                chatRoom =
+                    groupChatOpSet.createChatRoom(roomName, roomProperties);
+            }
 
             if(join)
             {


### PR DESCRIPTION
When MUCServiceImpl creates a chat room (i.e. a ChatRoomWrapper instance) it should first check to see if the chat room already exists and is already known by the protocol.

By first looking for an existing chat room, findRoom(...), before creating the chat room, we can make sure that we are not redundantly creating a chat room (and causing an OperationFailedException as a consequence).
Also, this becomes particularly relevant when the IRC protocol implementation is merged, since the IRC servers may automatically join a user to a particular channel, in which case the ChatRoom instance (related to the protocol implementation) exists, but the ChatRoomWrapper (related to the Jitsi core framework) does not yet.
