### PR TITLE
MainToolBar.call : Display chat transport resource name along with name

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/main/chat/toolBars/MainToolBar.java
+++ b/src/net/java/sip/communicator/impl/gui/main/chat/toolBars/MainToolBar.java
@@ -698,7 +698,7 @@ public class MainToolBar
             m.put(opSetClass, ct.getProtocolProvider());
 
             UIContactDetailImpl d = new UIContactDetailImpl(
-                                                ct.getName(),
+                                                ct.getName() + "  -  " + ct.getResourceName(),
                                                 ct.getDisplayName(),
                                                 null,
                                                 null,


### PR DESCRIPTION
In Jitsi desktop version, in the case of Jabber/XMPP accounts (specifically Google Talk), if a contact is signed in through multiple clients (Jitsi, Google Hangouts), each client has a unique resource ID. (For Jitsi, jitsi-xxxxx and for Hangouts, Messaging-xxxxx)

In a chat panel, when the audio/video call button is clicked, a dropdown menu is shown, with the list of different XMPP addresses - however only the main address is shown (user@servername - e.g sandy.8925@gmail.com) - the resource portion (jitsi-xxxx,Messaging-xxxx) is not shown. (see attached picture)
![jitsi_xmpp_dropdown_problem](https://cloud.githubusercontent.com/assets/830671/3223422/c08cae2a-f022-11e3-9bc4-1791321bf924.jpg)

So, when attempting to start an audio/video call through Jitsi, it is difficult to identify which endpoint/client needs to be selected since the resource is not shown - instead a list of multiple copies of the same email address is shown. This is important since Google Hangouts will not support audio/video calls with Jitsi, and the Jitsi client needs to be selected specifically.
