### PR TITLE
In the chat window's Edit menu, correct the shortcut key combination for...

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/main/chat/menus/EditMenu.java
+++ b/src/net/java/sip/communicator/impl/gui/main/chat/menus/EditMenu.java
@@ -97,7 +97,7 @@ public class EditMenu
                 KeyEvent.CTRL_MASK));
 
         this.pasteMenuItem.setAccelerator(
-                KeyStroke.getKeyStroke(KeyEvent.VK_P,
+                KeyStroke.getKeyStroke(KeyEvent.VK_V,
                 KeyEvent.CTRL_MASK));
     }
 


### PR DESCRIPTION
... the Paste action. Currently, it shows Ctrl+P but it should be Ctrl+V instead.

This fixes https://trac.jitsi.org/ticket/1097