### PR TITLE
VoiceCall Target resource

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/main/call/CallManager.java
+++ b/src/net/java/sip/communicator/impl/gui/main/call/CallManager.java
@@ -17,6 +17,7 @@ import javax.swing.*;
 
 import net.java.sip.communicator.impl.gui.*;
 import net.java.sip.communicator.impl.gui.main.*;
+import net.java.sip.communicator.impl.gui.main.chat.*;
 import net.java.sip.communicator.impl.gui.main.contactlist.*;
 import net.java.sip.communicator.plugin.desktoputil.*;
 import net.java.sip.communicator.plugin.desktoputil.transparent.*;

--- a/src/net/java/sip/communicator/impl/gui/main/call/CallManager.java
+++ b/src/net/java/sip/communicator/impl/gui/main/call/CallManager.java
@@ -17,7 +17,6 @@ import javax.swing.*;
 
 import net.java.sip.communicator.impl.gui.*;
 import net.java.sip.communicator.impl.gui.main.*;
-import net.java.sip.communicator.impl.gui.main.chat.*;
 import net.java.sip.communicator.impl.gui.main.contactlist.*;
 import net.java.sip.communicator.plugin.desktoputil.*;
 import net.java.sip.communicator.plugin.desktoputil.transparent.*;

--- a/src/net/java/sip/communicator/impl/gui/main/chat/toolBars/MainToolBar.java
+++ b/src/net/java/sip/communicator/impl/gui/main/chat/toolBars/MainToolBar.java
@@ -698,14 +698,19 @@ public class MainToolBar
             m.put(opSetClass, ct.getProtocolProvider());
 
             UIContactDetailImpl d = new UIContactDetailImpl(
-                                                ct.getName(),
+                                                ct.getName() + (ct.getResourceName() == null
+                                                    ? ""
+                                                    : "/" + ct.getResourceName()),
                                                 ct.getDisplayName(),
                                                 null,
-                                                null,
+                                                (ct.getResourceName() == null
+                                                    ? Arrays.asList(GuiActivator.getResources().getI18NString("service.gui.VIA") + ": "
+                                                        + ct.getProtocolProvider().getAccountID().getAccountAddress())
+                                                    : null),
                                                 null,
                                                 m,
                                                 null,
-                                                ct.getName());
+                                                ct);
             PresenceStatus status = ct.getStatus();
             byte[] statusIconBytes = status.getStatusIcon();
 
@@ -719,7 +724,7 @@ public class MainToolBar
 
             res.add(d);
         }
-
+        
         Point location = new Point(callButton.getX(),
             callButton.getY() + callButton.getHeight());
 

--- a/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetBasicTelephonyJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetBasicTelephonyJabberImpl.java
@@ -268,7 +268,10 @@ public class OperationSetBasicTelephonyJabberImpl
             Iterable<PacketExtension> sessionInitiateExtensions)
         throws OperationFailedException
     {
-        return createOutgoingCall(call, calleeAddress, null, null);
+        if (calleeAddress.contains("/"))
+            return createOutgoingCall(call, calleeAddress, calleeAddress, null);
+        else
+            return createOutgoingCall(call, calleeAddress, null, null);
     }
 
     /**


### PR DESCRIPTION
This small changes allows you to select the resource you want to call (if multiples exist).
Before, you saw the target name (without resource) the amount of times of resources +1.
No matter which one chosen, called always the preferred one.

The hack in my solution is not the best one, but it works at least for xmpp voice.

I don't know if this problem would exist with other protocols too.

(more information on "MainToolBar.call : Display chat transport resource name along with name")
