### PR TITLE
Could cause unnecessary exception

### DIFF
--- a/src/net/java/sip/communicator/plugin/provisioning/ProvisioningServiceImpl.java
+++ b/src/net/java/sip/communicator/plugin/provisioning/ProvisioningServiceImpl.java
@@ -427,7 +427,7 @@ public class ProvisioningServiceImpl
                                         getNetworkAddressManagerService().
                                             getHardwareAddress(iface);
 
-                                if(hw == null)
+                                if(hw == null || hw.length == 0)
                                     continue;
 
                                 StringBuffer buf =


### PR DESCRIPTION
Windows can have interface without MAC address, for example when using VPN.