### PR TITLE
Fix reference to transferCallButton

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/main/call/CallPanel.java
+++ b/src/net/java/sip/communicator/impl/gui/main/call/CallPanel.java
@@ -1674,7 +1674,7 @@ public class CallPanel
             settingsPanel.add(recordButton);
         if (showHideVideoButton != null)
             settingsPanel.add(showHideVideoButton);
-        if (mergeButton != null)
+        if (transferCallButton != null)
             settingsPanel.add(transferCallButton);
         if (videoButton != null)
             settingsPanel.add(videoButton);


### PR DESCRIPTION
As discussed on the mailing list, there is a NullPointerException if the transferCallButton is supposed to be hidden by 

```
net.java.sip.communicator.impl.gui.main.call.HIDE_CALL_TRANSFER_BUTTON=true
```

This pull request fixes the problem.
