### PR TITLE
Sip uri on boot

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/sip/UriHandlerSipImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/sip/UriHandlerSipImpl.java
@@ -38,7 +38,7 @@ public class UriHandlerSipImpl
      * Default value for INITIAL_REGISTRATION_TIMEOUT (milliseconds)
      */
     public static final long DEFAULT_INITIAL_REGISTRATION_TIMEOUT
-        = 2000;
+        = 5000;
 
     /**
      * The <tt>Logger</tt> used by the <tt>UriHandlerSipImpl</tt> class and its


### PR DESCRIPTION
I've observed the following on startup when dialing a URI from the command line:
- Jitsi displays an error saying that the user is not registered, asking if the user wants to register
- Whatever choice the user makes, a second error popup is displayed saying the call fails
- If the user clicks to register, the call is not attempted

This makes it more likely that the call will proceed

It also eliminates the second popup if the user clicks Yes in the first popup
