### PR TITLE
Adapt high-level API to allow calls without registration

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/sip/OperationSetBasicTelephonySipImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/sip/OperationSetBasicTelephonySipImpl.java
@@ -2091,7 +2091,8 @@ public class OperationSetBasicTelephonySipImpl
     private void assertRegistered()
         throws OperationFailedException
     {
-        if(!protocolProvider.isRegistered())
+        if(protocolProvider.isRegistrationRequiredForCalling() &&
+            !protocolProvider.isRegistered())
         {
             throw new OperationFailedException(
                     "The protocol provider should be registered before placing"

--- a/src/net/java/sip/communicator/impl/protocol/sip/ProtocolProviderServiceSipImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/sip/ProtocolProviderServiceSipImpl.java
@@ -235,6 +235,19 @@ public class ProtocolProviderServiceSipImpl
     }
 
     /**
+     * Indicates whether or not this provider must registered
+     * when placing outgoing calls.
+     *
+     * @return <tt>true</tt> if the provider must be registered when placing a
+     * call and <tt>false</tt> otherwise.
+     */
+    public boolean isRegistrationRequiredForCalling()
+    {
+        return getAccountID().getAccountPropertyBoolean(
+                        ProtocolProviderFactory.MUST_REGISTER_TO_CALL, true);
+    }
+
+    /**
      * Returns the state of the registration of this protocol provider with the
      * corresponding registration service.
      * @return ProviderRegistrationState

--- a/src/net/java/sip/communicator/service/protocol/AbstractProtocolProviderService.java
+++ b/src/net/java/sip/communicator/service/protocol/AbstractProtocolProviderService.java
@@ -279,6 +279,18 @@ public abstract class AbstractProtocolProviderService
     }
 
     /**
+     * Indicates whether or not this provider must registered
+     * when placing outgoing calls.
+     *
+     * @return <tt>true</tt> if the provider must be registered when placing a
+     * call and <tt>false</tt> otherwise.
+     */
+    public boolean isRegistrationRequiredForCalling()
+    {
+        return true;
+    }
+
+    /**
      * Removes the specified registration state change listener so that it does
      * not receive any further notifications upon changes of the
      * RegistrationState of this provider.

--- a/src/net/java/sip/communicator/service/protocol/ProtocolProviderFactory.java
+++ b/src/net/java/sip/communicator/service/protocol/ProtocolProviderFactory.java
@@ -174,6 +174,12 @@ public abstract class ProtocolProviderFactory
     public static final String FORCE_PROXY_BYPASS = "FORCE_PROXY_BYPASS";
 
     /**
+     * The name of the property that indicates whether the client must
+     * be registered with a registrar when making outgoing calls.
+     */
+    public static final String MUST_REGISTER_TO_CALL = "MUST_REGISTER_TO_CALL";
+
+    /**
      * The name of the property under which we store the user preference for a
      * transport protocol to use (i.e. tcp or udp).
      */

--- a/src/net/java/sip/communicator/service/protocol/ProtocolProviderService.java
+++ b/src/net/java/sip/communicator/service/protocol/ProtocolProviderService.java
@@ -81,6 +81,13 @@ public interface ProtocolProviderService
     public boolean isRegistered();
 
     /**
+     * Indicates whether or not this provider must registered
+     * when placing outgoing calls.
+     * @return true if the provider must be registered when placing a call.
+     */
+    public boolean isRegistrationRequiredForCalling();
+
+    /**
      * Returns the state of the registration of this protocol provider with the
      * corresponding registration service.
      * @return ProviderRegistrationState


### PR DESCRIPTION
This contribution does not change existing behavior unless the new account property MUST_REGISTER_TO_CALL is set to false (the default is true), e.g

```
net.java.sip.communicator.impl.protocol.sip.acc00001.MUST_REGISTER_TO_CALL=false
```

These are the high-level changes required, I suspect some low-level change may also be required as it doesn't currently work for TLS, when trying to make a call without being registered, it fails with the exception below.  Any feedback about this change would be very welcome.

```
     [java] java.lang.IllegalArgumentException: invalid transport
     [java] 	at net.java.sip.communicator.impl.protocol.sip.SipStackSharing.getJainSipProvider(SipStackSharing.java:474)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.ProtocolProviderServiceSipImpl.getJainSipProvider(ProtocolProviderServiceSipImpl.java:1573)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.ProtocolProviderServiceSipImpl.getDefaultJainSipProvider(ProtocolProviderServiceSipImpl.java:1952)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.SipMessageFactory.createInviteRequest(SipMessageFactory.java:724)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.SipMessageFactory.createInviteRequest(SipMessageFactory.java:864)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.CallSipImpl.invite(CallSipImpl.java:357)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.createOutgoingCall(OperationSetBasicTelephonySipImpl.java:173)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.OperationSetBasicTelephonySipImpl.createCall(OperationSetBasicTelephonySipImpl.java:118)
     [java] 	at net.java.sip.communicator.service.protocol.media.AbstractOperationSetBasicTelephony.createCall(AbstractOperationSetBasicTelephony.java:111)
     [java] 	at net.java.sip.communicator.impl.protocol.sip.UriHandlerSipImpl.handleUri(UriHandlerSipImpl.java:313)
     [java] 	at net.java.sip.communicator.impl.argdelegation.ArgDelegationPeerImpl.handleUri(ArgDelegationPeerImpl.java:186)
     [java] 	at net.java.sip.communicator.util.launchutils.ArgDelegator.handleUri(ArgDelegator.java:62)
     [java] 	at net.java.sip.communicator.util.launchutils.LaunchArgHandler.handleConcurrentInvocationRequestArgs(LaunchArgHandler.java:557)
     [java] 	at net.java.sip.communicator.util.launchutils.SipCommunicatorLock$LockServerConnectionProcessor.run(SipCommunicatorLock.java:827)
```