### PR TITLE
Removed path from recording result

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriConferenceIQ.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriConferenceIQ.java
@@ -1916,7 +1916,7 @@ public class ColibriConferenceIQ
         /**
          * The XML name of the <tt>path</tt> attribute.
          */
-        public static final String PATH_ATTR_NAME = "path";
+        public static final String DIRECTORY_ATTR_NAME = "directory";
 
         /**
          * The XML name of the <tt>state</tt> attribute.
@@ -1928,7 +1928,7 @@ public class ColibriConferenceIQ
          */
         public static final String TOKEN_ATTR_NAME = "token";
 
-        private String path;
+        private String directory;
 
         private boolean state;
 
@@ -1946,9 +1946,9 @@ public class ColibriConferenceIQ
             this.token = token;
         }
 
-        public String getPath()
+        public String getDirectory()
         {
-            return path;
+            return directory;
         }
 
         public boolean getState()
@@ -1966,9 +1966,9 @@ public class ColibriConferenceIQ
             this.token = token;
         }
 
-        public void setPath(String path)
+        public void setDirectory(String directory)
         {
-            this.path = path;
+            this.directory = directory;
         }
 
         public void toXML(StringBuilder xml)
@@ -1981,10 +1981,10 @@ public class ColibriConferenceIQ
                 xml.append(' ').append(TOKEN_ATTR_NAME).append("='")
                         .append(token).append('\'');
             }
-            if (path != null)
+            if (directory != null)
             {
-                xml.append(' ').append(PATH_ATTR_NAME).append("='")
-                        .append(path).append('\'');
+                xml.append(' ').append(DIRECTORY_ATTR_NAME).append("='")
+                        .append(directory).append('\'');
             }
             xml.append("/>");
         }


### PR DESCRIPTION
See https://github.com/jitsi/jitsi-videobridge/pull/32
Only the directory name of a recording should be submitted to the client, not the path.
