### PR TITLE
CertificateServiceImpl.java: fixed ambiguous Extension

### DIFF
--- a/src/net/java/sip/communicator/impl/certificate/CertificateServiceImpl.java
+++ b/src/net/java/sip/communicator/impl/certificate/CertificateServiceImpl.java
@@ -27,6 +27,7 @@ import net.java.sip.communicator.util.Logger;
 
 import org.bouncycastle.asn1.*;
 import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.x509.extension.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.resources.*;


### PR DESCRIPTION
added explicit import to avoid "CertificateServiceImpl.java:907: error: reference to Extension is ambiguous"
Fixed build for GNU/Linux with openjdk 1.8
