### PR TITLE
Enable GTKLookAndFeel on Linux/FreeBSD globally

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/UIServiceImpl.java
+++ b/src/net/java/sip/communicator/impl/gui/UIServiceImpl.java
@@ -897,19 +897,13 @@ public class UIServiceImpl
             {
                 try
                 {
-                    String kdeFullSession = System.getenv("KDE_FULL_SESSION");
-
-                    if ((kdeFullSession != null)
-                            && (kdeFullSession.length() != 0))
+                    for (LookAndFeelInfo lafi
+                            : UIManager.getInstalledLookAndFeels())
                     {
-                        for (LookAndFeelInfo lafi
-                                : UIManager.getInstalledLookAndFeels())
+                        if (gtkLookAndFeel.equals(lafi.getClassName()))
                         {
-                            if (gtkLookAndFeel.equals(lafi.getClassName()))
-                            {
-                                laf = gtkLookAndFeel;
-                                break;
-                            }
+                            laf = gtkLookAndFeel;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Right now, the native GTKLookAndFeel is only used when on a KDE session, which curiously enough is actually one of the few non-GTK-based DEs. The proposed changes enables GTKLookAndFeel to be used globally on Linux and FreeBSD, if the style is available, and gives users a much higher integration regardless their desktop environment of choice.

If there is a compelling reason on why not to enable it for other environments please tell me so I can look into another possible solution, because the out-of-the-box Jitsi UI experience on Linux could be much smoother. Thank you!
