### PR TITLE
Fix condition precedence

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/yahoo/ServerStoredContactListYahooImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/yahoo/ServerStoredContactListYahooImpl.java
@@ -1199,8 +1199,10 @@ public class ServerStoredContactListYahooImpl
                 Contact srcContact = findContactById(ev.getFrom());
 
                 if(srcContact == null)
+                {
                     if (logger.isTraceEnabled())
                         logger.trace("No contact found");
+                }
                 else
                     handler.processAuthorizationResponse(
                         new AuthorizationResponse(
@@ -1215,8 +1217,10 @@ public class ServerStoredContactListYahooImpl
                 Contact srcContact = findContactById(ev.getFrom());
 
                 if(srcContact == null)
+                {
                     if (logger.isTraceEnabled())
                         logger.trace("No contact found");
+                }
                 else
                 {
                     handler.processAuthorizationResponse(


### PR DESCRIPTION
Now `else` is related to inner `if`, which is obviously a bug. This way `srcContact ` will always be `null`.