### PR TITLE
Fixes the contacts 'message button' disappearing on offline contacts

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetContactCapabilitiesJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetContactCapabilitiesJabberImpl.java
@@ -489,7 +489,8 @@ public class OperationSetContactCapabilitiesJabberImpl
             if(JabberActivator.getConfigurationService()
                 .getBoolean(
                     PROP_XMPP_USE_ALL_RESOURCES_FOR_CAPABILITIES,
-                    USE_ALL_RESOURCES_FOR_CAPABILITIES_DEFAULT))
+                    USE_ALL_RESOURCES_FOR_CAPABILITIES_DEFAULT)
+                && !fullJids.isEmpty())
             {
                 String bareJid = StringUtils.parseBareAddress(user);
                 Contact contact = opsetPresence.findContactByID(bareJid);
@@ -570,7 +571,7 @@ public class OperationSetContactCapabilitiesJabberImpl
             .getBoolean(
                 PROP_XMPP_USE_ALL_RESOURCES_FOR_CAPABILITIES,
                 USE_ALL_RESOURCES_FOR_CAPABILITIES_DEFAULT)
-            ||fullJids.isEmpty())
+            || fullJids.isEmpty())
         {
             OperationSetPresence opsetPresence
             = parentProvider.getOperationSet(OperationSetPresence.class);


### PR DESCRIPTION
This is a fixup to https://github.com/jitsi/jitsi/pull/161 This introduced a bug in which a contact which just went offline to not have *messaging capabilities*. This is needed for opening the chat window to send offline messages. One clause was missing, causing the new behavior to check offline contacts for their capabilities. More specifically it checked their online resources and this will always be a null set on an offline contact. With this it now uses the old behavior for offline contacts, which returns a preset set of capabilities (e.g. messaging).