### PR TITLE
Fix TreeSet's Comparator in Jabber Presence class

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetPersistentPresenceJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetPersistentPresenceJabberImpl.java
@@ -1528,6 +1528,19 @@ public class OperationSetPersistentPresenceJabberImpl
                                         o2, parentProvider).getStatus()
                                       - jabberStatusToPresenceStatus(
                                             o1, parentProvider).getStatus();
+                                // We have run out of "logical" ways to order
+                                // the presences inside the TreeSet. We have
+                                // make sure we are consinstent with equals.
+                                // We do this by comparing the unique resource
+                                // names. If this evaluates to 0 again, then we
+                                // can safely assume this presence object 
+                                // represents the same resource and by that the
+                                // same client.
+                                if(res == 0)
+                                {
+                                    res = o1.getFrom().compareTo(
+                                        o2.getFrom());
+                                }
                             }
 
                             return res;


### PR DESCRIPTION
This fixes the Presence TreeSet's Comparator. If the comparator can't
determine a greater or less than relationship, it will sort by the name
of the resources lexicographically.
A (mathematical) set is a collection of distinct objects. A TreeSet's
compare function determines relation of two objects. It also determines
equality and since this is a Set, it would effectively replace the old
one in the set, if the function returns 0. This method wasn't fully
equals consistent, meaning different objects were deemed equal by the
comparator. That lead to an inconsistency in the representation of
presence objects and resources that contact has connected. The resources
not represented in this TreeSet would no longer be able to let the
contact appear as Online.

This resolves #182