### PR TITLE
Directimage fix

### DIFF
--- a/src/net/java/sip/communicator/impl/replacement/directimage/ReplacementServiceDirectImageImpl.java
+++ b/src/net/java/sip/communicator/impl/replacement/directimage/ReplacementServiceDirectImageImpl.java
@@ -45,7 +45,7 @@ public class ReplacementServiceDirectImageImpl
      * The regex used to match the link in the message.
      */
     public static final String URL_PATTERN =
-        "https?\\:\\/\\/*.*\\.(?:jpg|png|gif)";
+        "https?\\:\\/\\/.*\\.(?:jpg|png|gif)";
 
     /**
      * Configuration label shown in the config form.

--- a/src/net/java/sip/communicator/impl/replacement/directimage/ReplacementServiceDirectImageImpl.java
+++ b/src/net/java/sip/communicator/impl/replacement/directimage/ReplacementServiceDirectImageImpl.java
@@ -45,7 +45,7 @@ public class ReplacementServiceDirectImageImpl
      * The regex used to match the link in the message.
      */
     public static final String URL_PATTERN =
-        "https?\\:\\/\\/(www\\.)*.*\\.(?:jpg|png|gif)";
+        "https?\\:\\/\\/*.*\\.(?:jpg|png|gif)";
 
     /**
      * Configuration label shown in the config form.


### PR DESCRIPTION
I had problems with some image URLs not being replaced correctly on Windows.

Our internal XMPP server uses URLs of the form
   https://im.example.org:12345/abc/def/ghi/img.jpg
which weren't replaced. Other URLs worked fine though.

Tried the fix on Linux and it works perfectly fine.