### PR TITLE
Support running run.sh from any current working directory

### DIFF
--- a/resources/install/linux/run.sh
+++ b/resources/install/linux/run.sh
@@ -1,4 +1,5 @@
 mkdir -p $HOME/.sip-communicator/log
+cd `dirname $0`
 
 export PATH=$PATH:native
 export JAVA_HOME=jre


### PR DESCRIPTION
When stable package installs to user's $HOME/jitsi, currently, run.sh starts successfully only when CWD is $HOME/jitsi.
Don't know for which other cases run.sh is used, please take care to check.