### PR TITLE
Add healthcheck iq

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
@@ -152,6 +152,14 @@ public class ProtocolProviderServiceJabberImpl
     public static final String URN_IETF_RFC_3264 = "urn:ietf:rfc:3264";
 
     /**
+     * http://xmpp.org/extensions/xep-0092.html Software Version.
+     *
+     */
+    // Used in JVB
+    @SuppressWarnings("unused")
+    public static final String URN_XMPP_IQ_VERSION = "jabber:iq:version";
+
+    /**
      * Jingle's Discovery Info URN for "XEP-0294: Jingle RTP Header Extensions
      * Negotiation" support.
      */

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriIQProvider.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriIQProvider.java
@@ -900,32 +900,6 @@ public class ColibriIQProvider
                 }
             }
         }
-        else if (HealthCheckIQ.ELEMENT_NAME.equals(parser.getName())
-            && HealthCheckIQ.NAMESPACE.equals(namespace))
-        {
-            String rootElement = parser.getName();
-
-            iq = new HealthCheckIQ();
-
-            boolean done = false;
-
-            while (!done)
-            {
-                switch (parser.next())
-                {
-                    case XmlPullParser.END_TAG:
-                    {
-                        String name = parser.getName();
-
-                        if (rootElement.equals(name))
-                        {
-                            done = true;
-                        }
-                        break;
-                    }
-                }
-            }
-        }
         else
             iq = null;
 

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/health/HealthCheckIQ.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/health/HealthCheckIQ.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package net.java.sip.communicator.impl.protocol.jabber.extensions.colibri;
+package net.java.sip.communicator.impl.protocol.jabber.extensions.health;
 
 import org.jivesoftware.smack.packet.*;
 
@@ -35,7 +35,8 @@ public class HealthCheckIQ
     /**
      * XML namespace name for health check IQs.
      */
-    final static public String NAMESPACE = ColibriConferenceIQ.NAMESPACE;
+    final static public String NAMESPACE
+        = "http://jitsi.org/protocol/healthcheck";
 
     /**
      * {@inheritDoc}

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/health/HealthCheckIQProvider.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/health/HealthCheckIQProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Jitsi, the OpenSource Java VoIP and Instant Messaging client.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.java.sip.communicator.impl.protocol.jabber.extensions.health;
+
+import net.java.sip.communicator.service.protocol.jabber.*;
+
+import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smack.provider.*;
+
+import org.xmlpull.v1.*;
+
+/**
+ * The <tt>IQProvider</tt> for {@link HealthCheckIQ}.
+ *
+ * @author Pawel Domas
+ */
+public class HealthCheckIQProvider
+    implements IQProvider
+{
+    /**
+     * Registers <tt>HealthCheckIQProvider</tt> as an <tt>IQProvider</tt>
+     * in {@link AbstractSmackInteroperabilityLayer}.
+     */
+    public static void registerIQProvider()
+    {
+        AbstractSmackInteroperabilityLayer smackInteropLayer =
+            AbstractSmackInteroperabilityLayer.getInstance();
+
+        // ColibriStatsIQ
+        smackInteropLayer.addIQProvider(
+            HealthCheckIQ.ELEMENT_NAME,
+            HealthCheckIQ.NAMESPACE,
+            new HealthCheckIQProvider());
+    }
+
+    /**
+     * Parses <tt>HealthCheckIQ</tt>.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public IQ parseIQ(XmlPullParser parser)
+        throws Exception
+    {
+        String namespace = parser.getNamespace();
+        IQ iq;
+
+        if (HealthCheckIQ.ELEMENT_NAME.equals(parser.getName())
+            && HealthCheckIQ.NAMESPACE.equals(namespace))
+        {
+            String rootElement = parser.getName();
+
+            iq = new HealthCheckIQ();
+
+            boolean done = false;
+
+            while (!done)
+            {
+                switch (parser.next())
+                {
+                    case XmlPullParser.END_TAG:
+                    {
+                        String name = parser.getName();
+
+                        if (rootElement.equals(name))
+                        {
+                            done = true;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        else
+            iq = null;
+
+        return iq;
+    }
+}


### PR DESCRIPTION
The purpose of this PR is for the HealthCheckIQ to have it's own namespace, so that we can do disco-info for that feature. HealthCheckIQ parsing has been moved to new IQ provider class, as it does not make sense for the ColibriIQProvider to parse IQs from different namespace.

First commit adds constant for jabber:iq:version advertised in JVB feature list. It is going to be used in JVB, so that we can remove this "TODO":
https://github.com/jitsi/jitsi-videobridge/blob/master/src/main/java/org/jitsi/videobridge/xmpp/ComponentImpl.java#L150
It is not really related to HealthCheckIQ, but will be part of JVB's feature list modification PR.