### PR TITLE
Add .gitattributes to prevent future EOL problems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java text eol=lf diff=java


### PR DESCRIPTION
i still see some mixed CRLF LF files on my computer
```
./test/net/java/sip/communicator/slick/popupmessagehandler/PopupMessageHandlerSLick.java:                                  ASCII text, with CRLF, LF line terminators
./test/net/java/sip/communicator/slick/protocol/sip/TestAutoProxyDetection.java:                                           ASCII text, with CRLF, LF line terminators
./src/net/java/sip/communicator/plugin/contactinfo/ContactInfoActivator.java:                                              ASCII text, with CRLF line terminators
./src/net/java/sip/communicator/plugin/otr/ScOtrEngineImpl.java:                                                           HTML document, ASCII text, with CRLF, LF line terminators
./src/net/java/sip/communicator/plugin/desktoputil/X509CertificatePanel.java:                                              HTML document, ASCII text, with CRLF, LF line terminators
./src/net/java/sip/communicator/impl/sysactivity/SystemActivityNotifications.java:                                         ASCII text, with CRLF line terminators
./src/net/java/sip/communicator/impl/protocol/sip/net/ProxyConnection.java:                                                ASCII text, with CRLF line terminators
./src/net/java/sip/communicator/impl/protocol/sip/net/RFC5922Matcher.java:                                                 HTML document, ASCII text, with CRLF, LF line terminators
./src/net/java/sip/communicator/service/muc/ChatRoomProviderWrapperListener.java:                                   ASCII text, with CRLF line terminators
./src/net/java/sip/communicator/service/protocol/AccountManager.java:                                               ASCII text, with CRLF line terminators
```