### PR TITLE
Use string comparison instead of int comparison

### DIFF
--- a/resources/install/generic/run.sh
+++ b/resources/install/generic/run.sh
@@ -6,7 +6,7 @@ ARCH=`uname -m | sed -e s/x86_64/64/ -e s/i.86/32/`
 # Additionnal JVM arguments
 CLIENTARGS=""
 
-if [ $ARCH -eq 32 ]
+if [ $ARCH = 32 ]
 then
     CLIENTARGS="-client -Xmx256m"
 fi


### PR DESCRIPTION
Currently if the architecture is defined differently (such
as 'amd64' used in NetBSD), this comparison fails with:
[: amd64: bad number