### PR TITLE
Security Vulnerability: Jitsi as SIP-over-TLS client

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/sip/SipStackSharing.java
+++ b/src/net/java/sip/communicator/impl/protocol/sip/SipStackSharing.java
@@ -23,6 +23,7 @@ import gov.nist.javax.sip.stack.*;
 
 import java.io.*;
 import java.util.*;
+import javax.net.ssl.*;
 
 import javax.sip.*;
 import javax.sip.address.*;
@@ -134,6 +135,34 @@ public class SipStackSharing
 
             // Create SipStack object
             this.stack = sipFactory.createSipStack(sipStackProperties);
+
+            String[] enabledSuites = {
+                "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+                "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+                "TLS_RSA_WITH_AES_128_CBC_SHA",
+                "TLS_RSA_WITH_AES_256_CBC_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                "TLS_EMPTY_RENEGOTIATION_INFO_SCSV",
+            };
+            SSLServerSocketFactory ssf = (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
+            String[] defaultSuites = ssf.getDefaultCipherSuites();
+            List<String> offeredSuites = new ArrayList(enabledSuites.length);
+            for (String enabledSuite : enabledSuites)
+            {
+                if (Arrays.asList(defaultSuites).contains(enabledSuite))
+                {
+                    offeredSuites.add(enabledSuite);
+                }
+            }
+            String[] newCipherSuites = new String[offeredSuites.size()];
+            newCipherSuites = offeredSuites.toArray(newCipherSuites);
+            ((SipStackImpl)this.stack).setEnabledCipherSuites(newCipherSuites);
+
             if (logger.isTraceEnabled())
                 logger.trace("Created stack: " + this.stack);
 


### PR DESCRIPTION
When Jitsi creates a client connection via SIP-over-TLS, the JAIN-SIP library is offering four TLS Cipher-Suites. Beside the suites AES-128 and 3DES which are mentioned by the SIP specification ([RFC 3261](http://tools.ietf.org/html/rfc3261#section-26.2.1)), JAIN-SIP offers anonymous suites. These suites allow a man-in-the-middle (MitM) attack, because Jitsi cannot validate the server certificate, as there is no certificate involved.

*Steps to Reproduce*
1. Ubuntu 16.04 LTS
2. Wireshark installed and running
3. Jitsi installed via the [Debian repository](http://jitsi.org/Main/DebianRepository)
4. SIP username: for example `00038799999@secure.dus.net`
  any server with a DNS-SRV entry for SIPS+D2T works
5. SIP password: anything, does not matter
6. press the button ‘Sign-in’

*Expected Results*
see <http://lists.jitsi.org/pipermail/dev/2012-February/005003.html>

*Actual Results*
The TLS Client Hello message contains two anonymous Cipher Suites:
1. `TLS_RSA_WITH_AES_128_CBC_SHA`
2. `SSL_RSA_WITH_3DES_EDE_CBC_SHA`
3. `TLS_DH_anon_WITH_AES_128_CBC_SHA`
4. `SSL_DH_anon_WITH_3DES_EDE_CBC_SHA`
which were added because of <http://markmail.org/message/ayoqmo6tcipfho3x> which let to issue [JSIP-185](http://java.net/jira/browse/JSIP-185) (which was an incorrect analysis; I am going to report that with RestComm/JAIN-SIP and NIST/JAIN-SIP in a next step).

*Notes*
Since commit cd62892, Jitsi uses a different JAIN-SIP library. Previously, Jitsi offered the default suites of the installed Java Runtime (50 suites with OpenJDK 8 for Ubuntu 16.04 LTS). JAIN-SIP offers an API to control its TLS Cipher-Suites.
The proposed list of suites is inspired by the [latest](http://www.ssllabs.com/ssltest/clients.html) Mozilla Firefox and Google Chrome. For example, DHE based suites are not offered because older Java Runtimes limited the DH bit-size; Google has removed those suites as well. Jitsi supports sRTP/SDES with AES-128 and AES-256. Both, Google and Mozilla, prefer AES-128 over AES-256 for speed reasons.
This change was just tested with client connections. I am not sure, if there are any server connections and how to configure/test those scenarios.