### PR TITLE
Fixes pasting links under macosx. Fixes #352.

### DIFF
--- a/src/net/java/sip/communicator/impl/gui/main/chat/ChatTransferHandler.java
+++ b/src/net/java/sip/communicator/impl/gui/main/chat/ChatTransferHandler.java
@@ -33,7 +33,8 @@ import net.java.sip.communicator.plugin.desktoputil.*;
 import net.java.sip.communicator.service.contactlist.*;
 import net.java.sip.communicator.service.gui.*;
 import net.java.sip.communicator.service.protocol.*;
-import net.java.sip.communicator.util.*;
+import net.java.sip.communicator.util.Logger;
+import org.jitsi.util.*;
 
 /**
  * A TransferHandler that we use to handle copying, pasting and DnD operations
@@ -161,7 +162,7 @@ public class ChatTransferHandler
             }
         }
 
-        if (t.isDataFlavorSupported(uriListFlavor))
+        if (t.isDataFlavorSupported(uriListFlavor) && OSUtils.IS_LINUX)
         {
             try
             {


### PR DESCRIPTION
Extracting links from string list was some workaround for pasting/dropping files under linux, so leave that workaround only for linux. Haven't tested under any linux distro whether the standard javaFileListFlavor is now available, maybe it is fixed in newest java editions cause by the time this code was written java1.6 was the newest.