### PR TITLE
feat(colibri): Adds the RTP headers in the RTP description.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriBuilder.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriBuilder.java
@@ -600,22 +600,31 @@ public class ColibriBuilder
                     continue;
                 }
 
-                List<PayloadTypePacketExtension> pts = rtpPE.getPayloadTypes();
-                if (pts == null || pts.isEmpty())
-                {
-                    continue;
-                }
-
-                hasAnyChanges = true;
-
                 ColibriConferenceIQ.Channel channelRequest
                     = (ColibriConferenceIQ.Channel) getRequestChannel(
                             request.getOrCreateContent(contentName),
                             channel);
 
-                for (PayloadTypePacketExtension ptPE : pts)
+                List<PayloadTypePacketExtension> pts = rtpPE.getPayloadTypes();
+                if (pts != null && !pts.isEmpty())
                 {
-                    channelRequest.addPayloadType(ptPE);
+                    hasAnyChanges = true;
+                    for (PayloadTypePacketExtension ptPE : pts)
+                    {
+                        channelRequest.addPayloadType(ptPE);
+                    }
+                }
+
+                List<RTPHdrExtPacketExtension> hdrs
+                    = rtpPE.getExtmapList();
+
+                if (hdrs != null && !hdrs.isEmpty())
+                {
+                    hasAnyChanges = true;
+                    for (RTPHdrExtPacketExtension hdrPE : hdrs)
+                    {
+                        channelRequest.addRtpHeaderExtension(hdrPE);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When Jicofo updates the COLIBRI channels, it needs to include the
updated RTP headers along with everything else (payload types, SSRCs,
SSRC groups, transport, etc.).

Provides https://github.com/jitsi/jicofo/pull/216