### PR TITLE
Propfile config bug

### DIFF
--- a/src/net/java/sip/communicator/impl/configuration/ConfigurationActivator.java
+++ b/src/net/java/sip/communicator/impl/configuration/ConfigurationActivator.java
@@ -21,7 +21,6 @@ import com.sun.jna.*;
 
 import net.java.sip.communicator.util.ServiceUtils;
 
-import org.jitsi.impl.configuration.ConfigurationServiceImpl;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.fileaccess.*;
 import org.jitsi.service.libjitsi.*;

--- a/src/net/java/sip/communicator/impl/configuration/ConfigurationActivator.java
+++ b/src/net/java/sip/communicator/impl/configuration/ConfigurationActivator.java
@@ -21,6 +21,7 @@ import com.sun.jna.*;
 
 import net.java.sip.communicator.util.ServiceUtils;
 
+import org.jitsi.impl.configuration.ConfigurationServiceImpl;
 import org.jitsi.service.configuration.*;
 import org.jitsi.service.fileaccess.*;
 import org.jitsi.service.libjitsi.*;
@@ -41,7 +42,7 @@ public class ConfigurationActivator
     implements BundleActivator
 {
     /** Property name to force a properties file based configuration. */
-    public static final String PNAME_USE_PROPFILE_CONFIG = 
+    public static final String PNAME_USE_PROPFILE_CONFIG =
         "net.java.sip.communicator.impl.configuration.USE_PROPFILE_CONFIG";
 
     /**
@@ -50,6 +51,36 @@ public class ConfigurationActivator
      */
     private static final Logger logger
         = Logger.getLogger(ConfigurationActivator.class);
+
+    private static final String DEFAULT_PROPS_FILE_NAME
+            = "jitsi-defaults.properties";
+
+    /**
+     * Name of the file containing overrides (possibly set by the distributor)
+     * for any of the default properties.
+     */
+    private static final String DEFAULT_OVERRIDES_PROPS_FILE_NAME
+        = "jitsi-default-overrides.properties";
+
+    /**
+     * A set of immutable properties deployed with the application during
+     * install time. The properties in this file will be impossible to override
+     * and attempts to do so will simply be ignored.
+     * @see #defaultProperties
+     */
+    private Map<String, String> immutableDefaultProperties
+        = new HashMap<String, String>();
+
+    /**
+     * A set of properties deployed with the application during install time.
+     * Contrary to the properties in {@link #immutableDefaultProperties} the
+     * ones in this map can be overridden with call to the
+     * <tt>setProperty()</tt> methods. Still, re-setting one of these properties
+     * to <tt>null</tt> would cause for its initial value to be restored.
+     */
+    private Map<String, String> defaultProperties
+        = new HashMap<String, String>();
+
 
     /**
      * The currently registered {@link ConfigurationService} instance.
@@ -63,9 +94,93 @@ public class ConfigurationActivator
      * framework.
      * @throws Exception if anything goes wrong
      */
+
+     private void loadDefaultProperties(String fileName)
+     {
+         try
+         {
+             Properties fileProps = new Properties();
+
+             InputStream fileStream;
+             if(OSUtils.IS_ANDROID)
+             {
+                 fileStream
+                         = getClass().getClassLoader()
+                                 .getResourceAsStream(fileName);
+             }
+             else
+             {
+                 logger.info("Normal classloader");
+                 fileStream = ClassLoader.getSystemResourceAsStream(fileName);
+             }
+
+             if(fileStream == null)
+             {
+                 logger.info("failed to find " + fileName + " with class "
+                     + "loader, will continue without it.");
+                 return;
+             }
+
+             fileProps.load(fileStream);
+             fileStream.close();
+
+             // now get those properties and place them into the mutable and
+             // immutable properties maps.
+             for (Map.Entry<Object, Object> entry : fileProps.entrySet())
+             {
+                 String name  = (String) entry.getKey();
+                 String value = (String) entry.getValue();
+
+                 if (   name == null
+                     || value == null
+                     || name.trim().length() == 0)
+                 {
+                     continue;
+                 }
+
+                 if (name.startsWith("*"))
+                 {
+                     name = name.substring(1);
+
+                     if(name.trim().length() == 0)
+                     {
+                         continue;
+                     }
+
+                     //it seems that we have a valid default immutable property
+                     immutableDefaultProperties.put(name, value);
+
+                     //in case this is an override, make sure we remove previous
+                     //definitions of this property
+                     defaultProperties.remove(name);
+                 }
+                 else
+                 {
+                     //this property is a regular, mutable default property.
+                     defaultProperties.put(name, value);
+
+                     //in case this is an override, make sure we remove previous
+                     //definitions of this property
+                     immutableDefaultProperties.remove(name);
+                 }
+             }
+         }
+         catch (Exception ex)
+         {
+             //we can function without defaults so we are just logging those.
+             logger.info("No defaults property file loaded: " + fileName
+                 + ". Not a problem.");
+
+             if(logger.isDebugEnabled())
+                 logger.debug("load exception", ex);
+         }
+    }
+
     public void start(BundleContext bundleContext)
         throws Exception
     {
+        loadDefaultProperties(DEFAULT_PROPS_FILE_NAME);
+        loadDefaultProperties(DEFAULT_OVERRIDES_PROPS_FILE_NAME);
         if (usePropFileConfigService(bundleContext))
         {
             logger.info("Using properties file configuration store.");
@@ -89,19 +204,16 @@ public class ConfigurationActivator
 
     private boolean usePropFileConfigService(BundleContext bundleContext)
     {
-        if (Boolean.getBoolean(PNAME_USE_PROPFILE_CONFIG))
+        if (Boolean.valueOf(defaultProperties.get(PNAME_USE_PROPFILE_CONFIG)))
         {
             return true;
         }
-
         FileAccessService fas
             = ServiceUtils.getService(bundleContext, FileAccessService.class);
-
         if (fas == null)
         {
             return true;
         }
-
         try
         {
             return fas.getPrivatePersistentFile(

--- a/src/net/java/sip/communicator/impl/protocol/sip/sip.provider.manifest.mf
+++ b/src/net/java/sip/communicator/impl/protocol/sip/sip.provider.manifest.mf
@@ -91,7 +91,8 @@ Import-Package:  ch.imvs.sdes4j.srtp,
  org.osgi.framework,
  org.opentelecoms.javax.sdp,
  org.w3c.dom,
- org.xml.sax
+ org.xml.sax,
+ net.java.sip.communicator.plugin.notificationwiring
 Export-Package: net.java.sip.communicator.impl.protocol.sip,
  net.java.sip.communicator.impl.protocol.sip.net,
  net.java.sip.communicator.impl.protocol.sip.xcap,

--- a/src/net/java/sip/communicator/plugin/notificationwiring/NotificationManager.java
+++ b/src/net/java/sip/communicator/plugin/notificationwiring/NotificationManager.java
@@ -96,6 +96,11 @@ public class NotificationManager
     public static final String HANG_UP = "HangUp";
 
     /**
+     * Default event type for long hold.
+     */
+    public static final String LONG_HOLD = "LongHold";
+
+    /**
      * Default event type for receiving calls (incoming calls).
      */
     public static final String INCOMING_CALL = "IncomingCall";
@@ -1094,6 +1099,10 @@ public class NotificationManager
         }
     }
 
+    //static method to fire long hold event so we can access private method fireNotification
+    public static void alertHold() {
+        fireNotification(LONG_HOLD);
+    }
     /**
      * {@inheritDoc}
      *
@@ -1634,6 +1643,13 @@ public class NotificationManager
             NotificationAction.ACTION_POPUP_MESSAGE,
             null,
             null);
+
+        //audio alert for long hold
+        notificationService.registerDefaultNotificationForEvent(
+                LONG_HOLD,
+                new SoundNotificationAction(
+                        SoundProperties.BUSY, -1,
+                        true, true, false));
     }
 
     /**

--- a/src/net/java/sip/communicator/plugin/notificationwiring/notificationwiring.manifest.mf
+++ b/src/net/java/sip/communicator/plugin/notificationwiring/notificationwiring.manifest.mf
@@ -18,3 +18,4 @@ Import-Package: javax.imageio,
  org.jitsi.service.resources,
  org.osgi.framework,
  org.apache.commons.lang3
+Export-Package: net.java.sip.communicator.plugin.notificationwiring


### PR DESCRIPTION
I created a patch for a bug that was preventing the enabling of prop file configuration on Windows. The code to load from jitsi-defaults.properties and jitsi-default-overrides.properties was moved to JdbcConfigService.java, so the condition Windows systems needed to meet to enable prop config would always fail. This is tested and in production internally. 