### PR TITLE
fix jitsi could not transfer file with thumbnail

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/thumbnail/FileElement.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/thumbnail/FileElement.java
@@ -263,7 +263,7 @@ public class FileElement
                 }
                 else if (elementName.equals("thumbnail"))
                 {
-                    thumbnail = new ThumbnailElement(parser.getText());
+                    thumbnail = ThumbnailElement.parseExtension(parser);
                 }
             }
             else if (eventType == XmlPullParser.END_TAG)


### PR DESCRIPTION
The reason is that in the method **FileElement::parseIQ** where is the line <tt>thumbnail = new ThumbnailElement(parser.getText())</tt> where <tt>parser.getText()</tt> equals something like `<thumbnail xmlns="..." cid="..." mime-type="image/png" width="64" height="64">` (note closing '>' instead of '/>'). That's why exception occurs in the constructor of ThumbnailElement
    org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 160; XML document structures must start and end within the same entity.