### PR TITLE
added support for playing long hold alerts

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/sip/sip.provider.manifest.mf
+++ b/src/net/java/sip/communicator/impl/protocol/sip/sip.provider.manifest.mf
@@ -91,7 +91,8 @@ Import-Package:  ch.imvs.sdes4j.srtp,
  org.osgi.framework,
  org.opentelecoms.javax.sdp,
  org.w3c.dom,
- org.xml.sax
+ org.xml.sax,
+ net.java.sip.communicator.plugin.notificationwiring
 Export-Package: net.java.sip.communicator.impl.protocol.sip,
  net.java.sip.communicator.impl.protocol.sip.net,
  net.java.sip.communicator.impl.protocol.sip.xcap,

--- a/src/net/java/sip/communicator/plugin/notificationwiring/NotificationManager.java
+++ b/src/net/java/sip/communicator/plugin/notificationwiring/NotificationManager.java
@@ -96,6 +96,11 @@ public class NotificationManager
     public static final String HANG_UP = "HangUp";
 
     /**
+     * Default event type for long hold.
+     */
+    public static final String LONG_HOLD = "LongHold";
+
+    /**
      * Default event type for receiving calls (incoming calls).
      */
     public static final String INCOMING_CALL = "IncomingCall";
@@ -1094,6 +1099,10 @@ public class NotificationManager
         }
     }
 
+    //static method to fire long hold event so we can access private method fireNotification
+    public static void alertHold() {
+        fireNotification(LONG_HOLD);
+    }
     /**
      * {@inheritDoc}
      *
@@ -1634,6 +1643,13 @@ public class NotificationManager
             NotificationAction.ACTION_POPUP_MESSAGE,
             null,
             null);
+
+        //audio alert for long hold
+        notificationService.registerDefaultNotificationForEvent(
+                LONG_HOLD,
+                new SoundNotificationAction(
+                        SoundProperties.BUSY, -1,
+                        true, true, false));
     }
 
     /**

--- a/src/net/java/sip/communicator/plugin/notificationwiring/notificationwiring.manifest.mf
+++ b/src/net/java/sip/communicator/plugin/notificationwiring/notificationwiring.manifest.mf
@@ -18,3 +18,4 @@ Import-Package: javax.imageio,
  org.jitsi.service.resources,
  org.osgi.framework,
  org.apache.commons.lang3
+Export-Package: net.java.sip.communicator.plugin.notificationwiring


### PR DESCRIPTION
I added in a feature that checks for a property "net.java.sip.communicator.imp.protocol.sip.HOLD_ALERT_TIME". If this property is set, then Jitsi will play an alert noise when someone has been on hold for too long. This is really useful in a callcenter setting.
If the property is not set, the functionality is disabled. 