### PR TITLE
fix: Fixes copying of PayloadPacketExtension

### DIFF
--- a/m2/jitsi-argdelegation/pom.xml
+++ b/m2/jitsi-argdelegation/pom.xml
@@ -39,6 +39,20 @@
             <include>net/java/sip/communicator/service/argdelegation/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-certificate/pom.xml
+++ b/m2/jitsi-certificate/pom.xml
@@ -55,6 +55,20 @@
             <include>net/java/sip/communicator/impl/certificate/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-configuration/pom.xml
+++ b/m2/jitsi-configuration/pom.xml
@@ -46,6 +46,20 @@
             <include>net/java/sip/communicator/impl/configuration/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-contactlist/pom.xml
+++ b/m2/jitsi-contactlist/pom.xml
@@ -34,6 +34,20 @@
             <include>net/java/sip/communicator/service/contactlist/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-credentialsstorage/pom.xml
+++ b/m2/jitsi-credentialsstorage/pom.xml
@@ -39,6 +39,20 @@
             <include>net/java/sip/communicator/service/credentialsstorage/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-desktoputil/pom.xml
+++ b/m2/jitsi-desktoputil/pom.xml
@@ -40,6 +40,20 @@
             <include>net/java/sip/communicator/plugin/desktoputil/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-dns/pom.xml
+++ b/m2/jitsi-dns/pom.xml
@@ -44,6 +44,20 @@
             <include>net/java/sip/communicator/impl/dns/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-dnsservice/pom.xml
+++ b/m2/jitsi-dnsservice/pom.xml
@@ -33,6 +33,20 @@
             <include>net/java/sip/communicator/service/dns/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-fileaccess/pom.xml
+++ b/m2/jitsi-fileaccess/pom.xml
@@ -38,6 +38,20 @@
             <include>net/java/sip/communicator/impl/fileaccess/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-globaldisplaydetails/pom.xml
+++ b/m2/jitsi-globaldisplaydetails/pom.xml
@@ -36,6 +36,20 @@
             <include>net/java/sip/communicator/impl/globaldisplaydetails/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-hid/pom.xml
+++ b/m2/jitsi-hid/pom.xml
@@ -33,6 +33,20 @@
             <include>net/java/sip/communicator/service/hid/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-muc/pom.xml
+++ b/m2/jitsi-muc/pom.xml
@@ -34,6 +34,20 @@
             <include>net/java/sip/communicator/service/muc/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-neomedia/pom.xml
+++ b/m2/jitsi-neomedia/pom.xml
@@ -35,6 +35,20 @@
             <include>net/java/sip/communicator/impl/neomedia/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-netaddr/pom.xml
+++ b/m2/jitsi-netaddr/pom.xml
@@ -48,6 +48,20 @@
             <include>net/java/sip/communicator/service/netaddr/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-notification-service/pom.xml
+++ b/m2/jitsi-notification-service/pom.xml
@@ -35,6 +35,20 @@
             <include>net/java/sip/communicator/service/notification/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-packetlogging/pom.xml
+++ b/m2/jitsi-packetlogging/pom.xml
@@ -47,6 +47,20 @@
             <include>net/java/sip/communicator/impl/packetlogging/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-protocol-jabber/pom.xml
+++ b/m2/jitsi-protocol-jabber/pom.xml
@@ -98,6 +98,20 @@
             <include>net/java/sip/communicator/impl/protocol/jabber/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testIncludes>
+                <include>net/java/sip/communicator/impl/protocol/jabber/**</include>
+              </testIncludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-protocol-media/pom.xml
+++ b/m2/jitsi-protocol-media/pom.xml
@@ -44,6 +44,20 @@
             <include>net/java/sip/communicator/service/protocol/media/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-protocol-sip/pom.xml
+++ b/m2/jitsi-protocol-sip/pom.xml
@@ -75,6 +75,20 @@
             <include>net/java/sip/communicator/impl/protocol/sip/**.java</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-protocol/pom.xml
+++ b/m2/jitsi-protocol/pom.xml
@@ -47,6 +47,20 @@
             <include>net/java/sip/communicator/service/protocol/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-reconnect/pom.xml
+++ b/m2/jitsi-reconnect/pom.xml
@@ -35,6 +35,20 @@
             <include>net/java/sip/communicator/plugin/reconnectplugin/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-resourcemanager/pom.xml
+++ b/m2/jitsi-resourcemanager/pom.xml
@@ -39,6 +39,20 @@
             <include>net/java/sip/communicator/service/resources/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-sysactivity/pom.xml
+++ b/m2/jitsi-sysactivity/pom.xml
@@ -57,6 +57,20 @@
             <include>net/java/sip/communicator/impl/sysactivity/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/m2/jitsi-systray-service/pom.xml
+++ b/m2/jitsi-systray-service/pom.xml
@@ -35,6 +35,20 @@
             <include>net/java/sip/communicator/service/systray/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-ui-service/pom.xml
+++ b/m2/jitsi-ui-service/pom.xml
@@ -45,6 +45,20 @@
             <include>net/java/sip/communicator/service/shutdown/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-util/pom.xml
+++ b/m2/jitsi-util/pom.xml
@@ -50,6 +50,20 @@
             <include>net/java/sip/communicator/util/**</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/jitsi-version/pom.xml
+++ b/m2/jitsi-version/pom.xml
@@ -40,6 +40,20 @@
             <exclude>**/SipCommunicatorVersionTask.java</exclude>
           </excludes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <configuration>
+              <testExcludes>
+                <exclude>net/**</exclude>
+              </testExcludes>
+            </configuration>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/m2/pom.xml
+++ b/m2/pom.xml
@@ -70,6 +70,7 @@
 
   <build>
     <sourceDirectory>../../src</sourceDirectory>
+    <testSourceDirectory>../../test</testSourceDirectory>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/AbstractPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/AbstractPacketExtension.java
@@ -37,6 +37,44 @@ public abstract class AbstractPacketExtension
     implements ExtensionElement
 {
     /**
+     * Clones the attributes, namespace and text of a specific
+     * <tt>AbstractPacketExtension</tt> into a new
+     * <tt>AbstractPacketExtension</tt> instance of the same run-time type.
+     *
+     * @param src the <tt>AbstractPacketExtension</tt> to be cloned
+     * @return a new <tt>AbstractPacketExtension</tt> instance of the run-time
+     * type of the specified <tt>src</tt> which has the same attributes,
+     * namespace and text
+     * @throws Exception if an error occurs during the cloning of the specified
+     * <tt>src</tt>
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends AbstractPacketExtension> T clone(T src)
+    {
+        T dst = null;
+        try
+        {
+            dst = (T) src.getClass().newInstance();
+        }
+        catch (InstantiationException | IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        // attributes
+        for (String name : src.getAttributeNames())
+        {
+            dst.setAttribute(name, src.getAttribute(name));
+        }
+        // namespace
+        dst.setNamespace(src.getNamespace());
+        // text
+        dst.setText(src.getText());
+
+        return dst;
+    }
+
+    /**
      * The name space of this packet extension. Should remain <tt>null</tt> if
      * there's no namespace associated with this element.
      */
@@ -68,7 +106,7 @@ public abstract class AbstractPacketExtension
      * A list of extensions registered with this element.
      */
     private final List<ExtensionElement> childExtensions
-                                = new ArrayList<ExtensionElement>();
+                                = new ArrayList<>();
 
     /**
      * Creates an {@link AbstractPacketExtension} instance for the specified
@@ -245,10 +283,14 @@ public abstract class AbstractPacketExtension
     {
         synchronized(attributes)
         {
-            if(value != null)
+            if (value != null)
+            {
                 this.attributes.put(name, value);
+            }
             else
+            {
                 this.attributes.remove(name);
+            }
         }
     }
 
@@ -479,45 +521,5 @@ public abstract class AbstractPacketExtension
         }
 
         return result;
-    }
-
-    /**
-     * Clones the attributes, namespace and text of a specific
-     * <tt>AbstractPacketExtension</tt> into a new
-     * <tt>AbstractPacketExtension</tt> instance of the same run-time type.
-     *
-     * @param src the <tt>AbstractPacketExtension</tt> to be cloned
-     * @return a new <tt>AbstractPacketExtension</tt> instance of the run-time
-     * type of the specified <tt>src</tt> which has the same attributes,
-     * namespace and text
-     * @throws Exception if an error occurs during the cloning of the specified
-     * <tt>src</tt>
-     */
-    @SuppressWarnings("unchecked")
-    public static <T extends AbstractPacketExtension> T clone(T src)
-    {
-        T dst = null;
-        try
-        {
-            dst = (T) src.getClass().newInstance();
-        }
-        catch (InstantiationException e)
-        {
-            throw new RuntimeException(e);
-        }
-        catch (IllegalAccessException e)
-        {
-            throw new RuntimeException(e);
-        }
-
-        // attributes
-        for (String name : src.getAttributeNames())
-            dst.setAttribute(name, src.getAttribute(name));
-        // namespace
-        dst.setNamespace(src.getNamespace());
-        // text
-        dst.setText(src.getText());
-
-        return dst;
     }
 }

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriBuilder.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriBuilder.java
@@ -125,14 +125,14 @@ public class ColibriBuilder
         boolean added = false;
         for (PayloadTypePacketExtension payloadType : description.getPayloadTypes())
         {
-            channel.addPayloadType(new PayloadTypePacketExtension(payloadType));
+            channel.addPayloadType(PayloadTypePacketExtension.clone(payloadType));
             added = true;
         }
 
         for (RTPHdrExtPacketExtension rtpHdrExt : description.getExtmapList())
         {
             channel
-                .addRtpHeaderExtension(new RTPHdrExtPacketExtension(rtpHdrExt));
+                .addRtpHeaderExtension(RTPHdrExtPacketExtension.clone(rtpHdrExt));
             added = true;
         }
 

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriConferenceIQ.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriConferenceIQ.java
@@ -751,7 +751,8 @@ public class ColibriConferenceIQ
             Objects.requireNonNull(ext, "ext");
 
             // Create a new instance, because we are going to modify the NS
-            RTPHdrExtPacketExtension newExt = new RTPHdrExtPacketExtension(ext);
+            RTPHdrExtPacketExtension newExt
+                = RTPHdrExtPacketExtension.clone(ext);
 
             // Make sure that the parent namespace (COLIBRI) is used.
             newExt.setNamespace(null);

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/ParameterPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/ParameterPacketExtension.java
@@ -52,16 +52,6 @@ public class ParameterPacketExtension extends AbstractPacketExtension
     }
 
     /**
-     * Initializes a {@link ParameterPacketExtension} instance inheriting all
-     * of its fields from another instance.
-     * @param other the instance to inherit from.
-     */
-    public ParameterPacketExtension(ParameterPacketExtension other)
-    {
-        this(other.getName(), other.getValue());
-    }
-
-    /**
      * Creates a new {@link ParameterPacketExtension} instance and sets the
      * given name and value.
      */

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/PayloadTypePacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/PayloadTypePacketExtension.java
@@ -69,38 +69,35 @@ public class PayloadTypePacketExtension extends AbstractPacketExtension
     public static final String PTIME_ATTR_NAME = "ptime";
 
     /**
+     * Creates a deep copy of a {@link PayloadTypePacketExtension}.
+     * @param source the {@link PayloadTypePacketExtension} to copy.
+     * @return the copy.
+     */
+    public static PayloadTypePacketExtension clone(
+        PayloadTypePacketExtension source)
+    {
+        PayloadTypePacketExtension destination
+            = AbstractPacketExtension.clone(source);
+
+        for (RtcpFbPacketExtension rtcpFb : source.getRtcpFeedbackTypeList())
+        {
+            destination.addRtcpFeedbackType(RtcpFbPacketExtension.clone(rtcpFb));
+        }
+
+        for (ParameterPacketExtension parameter : source.getParameters())
+        {
+            destination.addParameter(ParameterPacketExtension.clone(parameter));
+        }
+
+        return destination;
+    }
+
+    /**
      * Creates a new {@link PayloadTypePacketExtension} instance.
      */
     public PayloadTypePacketExtension()
     {
         super(NAMESPACE, ELEMENT_NAME);
-    }
-
-    /**
-     * Initializes a {@link PayloadTypePacketExtension} instance inheriting all
-     * of its fields from another instance.
-     * @param other the instance to inherit from.
-     */
-    public PayloadTypePacketExtension(PayloadTypePacketExtension other)
-    {
-        this();
-
-        setChannels(other.getChannels());
-        setClockrate(other.getClockrate());
-        setId(other.getID());
-        setMaxptime(other.getMaxptime());
-        setName(other.getName());
-        setPtime(other.getPtime());
-
-        for (RtcpFbPacketExtension rtcpFb : getRtcpFeedbackTypeList())
-        {
-            addRtcpFeedbackType(new RtcpFbPacketExtension(rtcpFb));
-        }
-
-        for (ParameterPacketExtension parameter : getParameters())
-        {
-            addParameter(new ParameterPacketExtension(parameter));
-        }
     }
 
     /**

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/RTPHdrExtPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/RTPHdrExtPacketExtension.java
@@ -27,6 +27,11 @@ import org.jivesoftware.smack.packet.*;
 /**
  * RTP header extension.
  *
+ * <rtp-hdrext xmlns="urn:xmpp:jingle:apps:rtp:rtp-hdrext:0"
+ *   id="id" senders="both" uri="abcd">
+ *       <parameter name="attributes" value="attributes-value"/>
+ * </rtp-hdrext>
+ *
  * @author Sebastien Vincent
  */
 public class RTPHdrExtPacketExtension
@@ -70,6 +75,28 @@ public class RTPHdrExtPacketExtension
     public RTPHdrExtPacketExtension()
     {
         super(NAMESPACE, ELEMENT_NAME);
+    }
+
+    /**
+     * Creates a deep copy of a {@link PayloadTypePacketExtension}.
+     * @param source the {@link PayloadTypePacketExtension} to copy.
+     * @return the copy.
+     */
+    public static RTPHdrExtPacketExtension clone(
+        RTPHdrExtPacketExtension source)
+    {
+        RTPHdrExtPacketExtension destination
+            = AbstractPacketExtension.clone(source);
+
+        // Note that this has no relation to the XML attributes of the extension.
+        // It is a value transported in a "parameter" child extension.
+        String attributes = source.getAttributes();
+        if (attributes != null)
+        {
+            destination.setAttributes(attributes);
+        }
+
+        return destination;
     }
 
     public RTPHdrExtPacketExtension(RTPHdrExtPacketExtension ext)
@@ -160,6 +187,9 @@ public class RTPHdrExtPacketExtension
 
         paramExt.setName(ATTRIBUTES_ATTR_NAME);
         paramExt.setValue(attributes);
+
+        // The rtp-hdrext extension can only contain a single "parameter" child
+        getChildExtensions().clear();
         addChildExtension(paramExt);
     }
 
@@ -170,13 +200,13 @@ public class RTPHdrExtPacketExtension
      */
     public String getAttributes()
     {
-        for(ExtensionElement ext : getChildExtensions())
+        for (ExtensionElement ext : getChildExtensions())
         {
-            if(ext instanceof ParameterPacketExtension)
+            if (ext instanceof ParameterPacketExtension)
             {
                 ParameterPacketExtension p = (ParameterPacketExtension)ext;
 
-                if(p.getName().equals(ATTRIBUTES_ATTR_NAME))
+                if (p.getName().equals(ATTRIBUTES_ATTR_NAME))
                 {
                     return p.getValue();
                 }

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/RtcpFbPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/RtcpFbPacketExtension.java
@@ -57,19 +57,6 @@ public class RtcpFbPacketExtension
     }
 
     /**
-     * Initializes a {@link RtcpFbPacketExtension} instance inheriting all of
-     * its fields from another instance.
-     * @param other the instance to inherit from.
-     */
-    public RtcpFbPacketExtension(RtcpFbPacketExtension other)
-    {
-        this();
-
-        setFeedbackType(other.getFeedbackType());
-        setFeedbackSubtype(other.getFeedbackSubtype());
-    }
-
-    /**
      * Sets RTCP feedback type attribute.
      * @param feedbackType the RTCP feedback type to set.
      */

--- a/test/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriIQProviderTest.java
+++ b/test/net/java/sip/communicator/impl/protocol/jabber/extensions/colibri/ColibriIQProviderTest.java
@@ -144,7 +144,6 @@ public class ColibriIQProviderTest extends TestCase
         assertEquals(ColibriConferenceIQ.ELEMENT_NAME, name);
 
         IQ result = colibriIQProvider.parse(xmlPullParser, 0);
-        System.out.println(result.toXML());
         List<SourcePacketExtension> sources =
                 ((ColibriConferenceIQ) result)
                         .getContent("video")

--- a/test/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/PayloadTypePacketExtensionTest.java
+++ b/test/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/PayloadTypePacketExtensionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Jitsi, the OpenSource Java VoIP and Instant Messaging client.
+ *
+ * Copyright @ 2015-2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.java.sip.communicator.impl.protocol.jabber.extensions.jingle;
+
+import junit.framework.*;
+
+import java.util.*;
+
+/**
+ * Tests {@link PayloadTypePacketExtension} as well as it's children (
+ * {@link ParameterPacketExtension} and {@link RtcpFbPacketExtension}).
+ *
+ * @author Boris Grozev
+ */
+public class PayloadTypePacketExtensionTest
+    extends TestCase
+{
+    /**
+     * Tests the
+     * {@link PayloadTypePacketExtension#clone(PayloadTypePacketExtension)}
+     * method.
+     */
+    public void testClone()
+    {
+        PayloadTypePacketExtension p = new PayloadTypePacketExtension();
+        p.setId(101);
+        p.setName("opus");
+        ParameterPacketExtension apt
+            = new ParameterPacketExtension("apt", "100");
+        p.addParameter(apt);
+
+        RtcpFbPacketExtension fb = new RtcpFbPacketExtension();
+        fb.setFeedbackType("nack");
+        fb.setFeedbackSubtype("pli");
+        p.addRtcpFeedbackType(fb);
+
+        assertEquals(1, p.getRtcpFeedbackTypeList().size());
+        assertEquals(1, p.getParameters().size());
+
+        PayloadTypePacketExtension c = PayloadTypePacketExtension.clone(p);
+        assertEquals(p.getChannels(), c.getChannels());
+        assertEquals(p.getName(), c.getName());
+        assertEquals(1, c.getParameters().size());
+        assertEquals(1, c.getRtcpFeedbackTypeList().size());
+        assertEquals(p.getID(), c.getID());
+
+        c.setChannels(2);
+        assertEquals(1, p.getChannels());
+        assertEquals(2, c.getChannels());
+
+        c.setName("vp8");
+        assertEquals("opus", p.getName());
+        assertEquals("vp8", c.getName());
+
+        ParameterPacketExtension cApt = c.getParameters().get(0);
+        assertTrue(apt != cApt);
+        assertEquals(apt.getName(), cApt.getName());
+        assertEquals(apt.getValue(), cApt.getValue());
+        cApt.setName("stereo");
+        assertEquals("apt", apt.getName());
+
+        RtcpFbPacketExtension cFb = c.getRtcpFeedbackTypeList().get(0);
+        assertTrue(fb != cFb);
+        assertEquals(fb.getFeedbackType(), cFb.getFeedbackType());
+        assertEquals(fb.getFeedbackSubtype(), cFb.getFeedbackSubtype());
+        cFb.setFeedbackType("x1");
+        cFb.setFeedbackSubtype("x2");
+        assertEquals("nack", fb.getFeedbackType());
+        assertEquals("pli", fb.getFeedbackSubtype());
+
+
+        Set<String> attributeNames = new HashSet<>(p.getAttributeNames());
+        attributeNames.addAll(c.getAttributeNames());
+
+        attributeNames.remove(PayloadTypePacketExtension.CHANNELS_ATTR_NAME);
+        attributeNames.remove(PayloadTypePacketExtension.ID_ATTR_NAME);
+        attributeNames.remove(PayloadTypePacketExtension.NAME_ATTR_NAME);
+
+        for (String s : attributeNames)
+        {
+            assertEquals(c.getAttribute(s), p.getAttribute(s));
+        }
+    }
+}

--- a/test/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/PayloadTypePacketExtensionTest.java
+++ b/test/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/PayloadTypePacketExtensionTest.java
@@ -30,6 +30,9 @@ import java.util.*;
 public class PayloadTypePacketExtensionTest
     extends TestCase
 {
+    private static final String TEST_ATTR_NAME = "my-test-attribute-name";
+    private static final String TEST_ATTR_VALUE = "my-test-attribute-value";
+
     /**
      * Tests the
      * {@link PayloadTypePacketExtension#clone(PayloadTypePacketExtension)}
@@ -43,14 +46,12 @@ public class PayloadTypePacketExtensionTest
         ParameterPacketExtension apt
             = new ParameterPacketExtension("apt", "100");
         p.addParameter(apt);
+        p.setAttribute(TEST_ATTR_NAME, TEST_ATTR_VALUE);
 
         RtcpFbPacketExtension fb = new RtcpFbPacketExtension();
         fb.setFeedbackType("nack");
         fb.setFeedbackSubtype("pli");
         p.addRtcpFeedbackType(fb);
-
-        assertEquals(1, p.getRtcpFeedbackTypeList().size());
-        assertEquals(1, p.getParameters().size());
 
         PayloadTypePacketExtension c = PayloadTypePacketExtension.clone(p);
         assertEquals(p.getChannels(), c.getChannels());
@@ -61,11 +62,9 @@ public class PayloadTypePacketExtensionTest
 
         c.setChannels(2);
         assertEquals(1, p.getChannels());
-        assertEquals(2, c.getChannels());
 
         c.setName("vp8");
         assertEquals("opus", p.getName());
-        assertEquals("vp8", c.getName());
 
         ParameterPacketExtension cApt = c.getParameters().get(0);
         assertTrue(apt != cApt);
@@ -95,5 +94,32 @@ public class PayloadTypePacketExtensionTest
         {
             assertEquals(c.getAttribute(s), p.getAttribute(s));
         }
+
+        c.setAttribute(TEST_ATTR_NAME, "WRONG");
+        assertEquals(p.getAttribute(TEST_ATTR_NAME), TEST_ATTR_VALUE);
+    }
+
+    public void testSettersAndGetters()
+    {
+        PayloadTypePacketExtension p = new PayloadTypePacketExtension();
+
+        p.setId(101);
+        assertEquals(101, p.getID());
+
+        p.setName("opus");
+        assertEquals("opus", p.getName());
+
+        ParameterPacketExtension apt
+            = new ParameterPacketExtension("apt", "100");
+        p.addParameter(apt);
+        assertEquals(1, p.getParameters().size());
+        assertEquals(apt, p.getParameters().get(0));
+
+        RtcpFbPacketExtension fb = new RtcpFbPacketExtension();
+        fb.setFeedbackType("nack");
+        fb.setFeedbackSubtype("pli");
+        p.addRtcpFeedbackType(fb);
+        assertEquals(1, p.getRtcpFeedbackTypeList().size());
+        assertEquals(fb, p.getRtcpFeedbackTypeList().get(0));
     }
 }


### PR DESCRIPTION
Uses a static clone() method instead of a copy constructor, because
AbstractPacketExtension already has one, which can be easily reused to
copy all attributes.