### PR TITLE
Fix the issue with IP-address in uri for the xmpp call from a command line

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/UriHandlerJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/UriHandlerJabberImpl.java
@@ -329,7 +329,7 @@ public class UriHandlerJabberImpl
 
             //todo check url!!
             //Set the email pattern string
-            Pattern p = Pattern.compile(".+@.+\\.[a-z]+");
+            Pattern p = Pattern.compile(".+@.+");
             if(!p.matcher(contactId).matches())
             {
                 showErrorMessage(


### PR DESCRIPTION
Allow use IP-addreses after `@` in contact uri, e.g. `user@192.168.0.1`.