### PR TITLE
Changes to Jibri recording flows

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
@@ -582,7 +582,7 @@ public class JibriIq
         /**
          * Unknown/uninitialized.
          */
-        UNDEFINED("undefined"),
+        UNDEFINED("undefined");
 
         /**
          * Used by {@link SipGatewayStatus} to signal that there are Jibris
@@ -592,7 +592,7 @@ public class JibriIq
          * Check {@link SipGatewayStatus} and {@link SipCallState} for more
          * info.
          */
-        AVAILABLE("available");
+//        AVAILABLE("available");
 
         /**
          * Status name holder.

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
@@ -92,6 +92,11 @@ public class JibriIq
     static final String YOUTUBE_BROADCAST_ID_ATTR_NAME = "you_tube_broadcast_id";
 
     /**
+     * The name of the XML attribute which stores the {@link #sessionId}
+     */
+    static final String SESSION_ID_ATTR_NAME = "session_id";
+
+    /**
      * The name of XML attribute which stores the recording mode which can be
      * either 'stream' or 'file'. If the attribute is not present, but
      * {@link #STREAM_ID_ATTR_NAME} is, then it defaults to 'stream'. But if
@@ -151,6 +156,15 @@ public class JibriIq
      * with a known URL to generate the URL to view the stream.
      */
     private String youTubeBroadcastId = null;
+
+    /**
+     * The ID for this Jibri session.  This ID is used to uniquely identify this
+     * session (i.e. this particular file recording or live stream).  It is returned
+     * in the ACK of the initial start request and should be used in all subsequent IQ
+     * messages regarding this session.  When Jibri joins the call, it will use
+     * this same session ID in its presence so that the association can be made
+     */
+    private String sessionId;
 
     /**
      * The name of the conference room to be recorded.
@@ -234,6 +248,18 @@ public class JibriIq
     }
 
     /**
+     * Gets the value of the {@link #SESSION_ID_ATTR_NAME} attribute
+     * @return the session ID
+     */
+    public String getSessionId() { return sessionId; }
+
+    /**
+     * Sets the value of the {@link #SESSION_ID_ATTR_NAME} attribute
+     * @param sessionId the session ID
+     */
+    public void setSessionId(String sessionId) { this.sessionId = sessionId; }
+
+    /**
      * Returns the value of {@link #ROOM_ATTR_NAME} attribute.
      * @return a <tt>String</tt> which contains the value of the room attribute
      *         or <tt>null</tt> if empty.
@@ -281,6 +307,7 @@ public class JibriIq
         xml.optAttribute(YOUTUBE_BROADCAST_ID_ATTR_NAME, youTubeBroadcastId);
         xml.optAttribute(DISPLAY_NAME_ATTR_NAME, displayName);
         xml.optAttribute(SIP_ADDRESS_ATTR_NAME, sipAddress);
+        xml.optAttribute(SESSION_ID_ATTR_NAME, sessionId);
 
         xml.setEmptyElement();
 
@@ -362,6 +389,27 @@ public class JibriIq
     public XMPPError getError()
     {
         return error;
+    }
+
+    public static JibriIq createResult(JibriIq request, String sessionId, JibriIq.Status status) {
+        JibriIq result = new JibriIq();
+        result.setType(IQ.Type.result);
+        result.setStanzaId(request.getStanzaId());
+        result.setTo(request.getFrom());
+        result.setSessionId(sessionId);
+        result.setStatus(status);
+
+        return result;
+    }
+
+    public static JibriIq createResult(JibriIq request, String sessionId) {
+        JibriIq result = new JibriIq();
+        result.setType(IQ.Type.result);
+        result.setStanzaId(request.getStanzaId());
+        result.setTo(request.getFrom());
+        result.setSessionId(sessionId);
+
+        return result;
     }
 
     /**

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
@@ -81,7 +81,7 @@ public class JibriIq
     static final String STATUS_ATTR_NAME = "status";
 
     /**
-     * The name of XML attribute which stores the recording status.
+     * The name of XML attribute which stores the optional failure reason
      */
     static final String FAILURE_REASON_ATTR_NAME = "failure_reason";
 
@@ -145,6 +145,10 @@ public class JibriIq
      */
     private Status status = Status.UNDEFINED;
 
+    /**
+     * An optional description for the 'OFF' state which can be used
+     * to describe an 'unclean' to transition to off (e.g. 'error')
+     */
     private FailureReason failureReason = null;
 
     /**
@@ -160,13 +164,14 @@ public class JibriIq
     private String youTubeBroadcastId = null;
 
     /**
-     * The ID for this Jibri session.  This ID is used to uniquely identify this
-     * session (i.e. this particular file recording or live stream).  It is returned
-     * in the ACK of the initial start request and should be used in all subsequent IQ
-     * messages regarding this session.  When Jibri joins the call, it will use
-     * this same session ID in its presence so that the association can be made
+     * The ID for this Jibri session.  This ID is used to uniquely identify
+     * this session (i.e. this particular file recording, live stream or
+     * SIP call).  It is returned in the ACK of the initial start request
+     * and should be used in all subsequent IQ messages regarding this
+     * session.  When Jibri joins the call, it will use this same
+     * session ID in its presence so that the association can be made
      */
-    private String sessionId;
+    private String sessionId = null;
 
     /**
      * The name of the conference room to be recorded.
@@ -382,6 +387,7 @@ public class JibriIq
         return this.failureReason;
     }
 
+    //TODO: think this can go away.  verify.
     public static JibriIq createResult(JibriIq request, String sessionId, JibriIq.Status status)
     {
         JibriIq result = new JibriIq();

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIq.java
@@ -169,7 +169,8 @@ public class JibriIq
      * SIP call).  It is returned in the ACK of the initial start request
      * and should be used in all subsequent IQ messages regarding this
      * session.  When Jibri joins the call, it will use this same
-     * session ID in its presence so that the association can be made
+     * session ID in its presence so that an association can be made
+     * between this signaling flow and the Jibri client.
      */
     private String sessionId = null;
 
@@ -385,19 +386,6 @@ public class JibriIq
     public FailureReason getFailureReason()
     {
         return this.failureReason;
-    }
-
-    //TODO: think this can go away.  verify.
-    public static JibriIq createResult(JibriIq request, String sessionId, JibriIq.Status status)
-    {
-        JibriIq result = new JibriIq();
-        result.setType(IQ.Type.result);
-        result.setStanzaId(request.getStanzaId());
-        result.setTo(request.getFrom());
-        result.setSessionId(sessionId);
-        result.setStatus(status);
-
-        return result;
     }
 
     public static JibriIq createResult(JibriIq request, String sessionId)

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIqProvider.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIqProvider.java
@@ -94,6 +94,13 @@ public class JibriIqProvider
                 iq.setSessionId(sessionId);
             }
 
+            String failureStr
+                    = parser.getAttributeValue("", JibriIq.FAILURE_REASON_ATTR_NAME);
+            if (!StringUtils.isNullOrEmpty(failureStr))
+            {
+                iq.setFailureReason(JibriIq.FailureReason.parse(failureStr));
+            }
+
             String displayName
                 = parser.getAttributeValue("", JibriIq.DISPLAY_NAME_ATTR_NAME);
             if (!StringUtils.isNullOrEmpty(displayName))
@@ -107,36 +114,6 @@ public class JibriIqProvider
         else
         {
             return null;
-        }
-
-        boolean done = false;
-
-        while (!done)
-        {
-            switch (parser.next())
-            {
-                case XmlPullParser.START_TAG:
-                {
-                    String name = parser.getName();
-
-                    if ("error".equals(name))
-                    {
-                        XMPPError error = PacketParserUtils.parseError(parser).build();
-                        iq.setXMPPError(error);
-                    }
-                    break;
-                }
-                case XmlPullParser.END_TAG:
-                {
-                    String name = parser.getName();
-
-                    if (rootElement.equals(name))
-                    {
-                        done = true;
-                    }
-                    break;
-                }
-            }
         }
 
         return iq;

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIqProvider.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriIqProvider.java
@@ -88,6 +88,12 @@ public class JibriIqProvider
             if (!StringUtils.isNullOrEmpty(youTubeBroadcastId))
                 iq.setYouTubeBroadcastId(youTubeBroadcastId);
 
+            String sessionId = parser.getAttributeValue("", JibriIq.SESSION_ID_ATTR_NAME);
+            if (!StringUtils.isNullOrEmpty(sessionId))
+            {
+                iq.setSessionId(sessionId);
+            }
+
             String displayName
                 = parser.getAttributeValue("", JibriIq.DISPLAY_NAME_ATTR_NAME);
             if (!StringUtils.isNullOrEmpty(displayName))

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
@@ -85,17 +85,29 @@ public class RecordingStatus
         return getAttributeAsString(JibriIq.SESSION_ID_ATTR_NAME);
     }
 
+    /**
+     * Set the session ID for this recording status element
+     * @param sessionId the session ID
+     */
     public void setSessionId(String sessionId)
     {
         setAttribute(JibriIq.SESSION_ID_ATTR_NAME, sessionId);
     }
 
+    /**
+     * Get the failure reason in this status, or UNDEFINED if there isn't one
+     * @return the failure reason
+     */
     public JibriIq.FailureReason getFailureReason()
     {
         String failureReasonStr = getAttributeAsString(JibriIq.FAILURE_REASON_ATTR_NAME);
         return JibriIq.FailureReason.parse(failureReasonStr);
     }
 
+    /**
+     * Set the failure reason in this status
+     * @param failureReason the failure reason
+     */
     public void setFailureReason(JibriIq.FailureReason failureReason)
     {
         if (failureReason != null)

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
@@ -51,12 +51,6 @@ public class RecordingStatus
      */
     private static final String STATUS_ATTRIBUTE = "status";
 
-    /**
-     * The name of the XML attribute which holds the session id
-     * of this status element
-     */
-    private static final String SESSION_ID_ATTRIBUTE = "session-id";
-
     public RecordingStatus()
     {
         super(NAMESPACE, ELEMENT_NAME);
@@ -88,12 +82,26 @@ public class RecordingStatus
      */
     public String getSessionId()
     {
-        return getAttributeAsString(SESSION_ID_ATTRIBUTE);
+        return getAttributeAsString(JibriIq.SESSION_ID_ATTR_NAME);
     }
 
     public void setSessionId(String sessionId)
     {
-        setAttribute(SESSION_ID_ATTRIBUTE, sessionId);
+        setAttribute(JibriIq.SESSION_ID_ATTR_NAME, sessionId);
+    }
+
+    public JibriIq.FailureReason getFailureReason()
+    {
+        String failureReasonStr = getAttributeAsString(JibriIq.FAILURE_REASON_ATTR_NAME);
+        return JibriIq.FailureReason.parse(failureReasonStr);
+    }
+
+    public void setFailureReason(JibriIq.FailureReason failureReason)
+    {
+        if (failureReason != null)
+        {
+            setAttribute(JibriIq.FAILURE_REASON_ATTR_NAME, failureReason.toString());
+        }
     }
 
     /**

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
@@ -94,6 +94,17 @@ public class RecordingStatus
         setAttribute(JibriIq.SESSION_ID_ATTR_NAME, sessionId);
     }
 
+    public JibriIq.RecordingMode getRecordingMode()
+    {
+        String recordingMode = getAttributeAsString(JibriIq.RECORDING_MODE_ATTR_NAME);
+        return JibriIq.RecordingMode.parse(recordingMode);
+    }
+
+    public void setRecordingMode(JibriIq.RecordingMode recordingMode)
+    {
+        setAttribute(JibriIq.RECORDING_MODE_ATTR_NAME, recordingMode.toString());
+    }
+
     /**
      * Get the failure reason in this status, or UNDEFINED if there isn't one
      * @return the failure reason

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/RecordingStatus.java
@@ -51,6 +51,12 @@ public class RecordingStatus
      */
     private static final String STATUS_ATTRIBUTE = "status";
 
+    /**
+     * The name of the XML attribute which holds the session id
+     * of this status element
+     */
+    private static final String SESSION_ID_ATTRIBUTE = "session-id";
+
     public RecordingStatus()
     {
         super(NAMESPACE, ELEMENT_NAME);
@@ -74,6 +80,20 @@ public class RecordingStatus
     public void setStatus(JibriIq.Status status)
     {
         setAttribute(STATUS_ATTRIBUTE, String.valueOf(status));
+    }
+
+    /**
+     * Returns the session ID stored in this element
+     * @return the session ID
+     */
+    public String getSessionId()
+    {
+        return getAttributeAsString(SESSION_ID_ATTRIBUTE);
+    }
+
+    public void setSessionId(String sessionId)
+    {
+        setAttribute(SESSION_ID_ATTRIBUTE, sessionId);
     }
 
     /**

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/SipCallState.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/SipCallState.java
@@ -30,9 +30,8 @@ import java.util.*;
  * Status meaning:
  * <tt>{@link JibriIq.Status#PENDING}</tt> - (initial) SIP call is being started
  * <tt>{@link JibriIq.Status#ON}</tt> - SIP call in progress
- * <tt>{@link JibriIq.Status#OFF}</tt> - SIP call has been stopped
- * <tt>{@link JibriIq.Status#FAILED}</tt> - SIP call has failed, check
- * {@link #getError()} for more details about the error
+ * <tt>{@link JibriIq.Status#OFF}</tt> - SIP call has been stopped.  If it was
+ * not a graceful transition to OFF, a FailureReason will also be given
  *
  * @author Pawel Domas
  */
@@ -103,53 +102,17 @@ public class SipCallState
         setAttribute(STATE_ATTRIBUTE, String.valueOf(status));
     }
 
-    /**
-     * Returns <tt>XMPPError</tt> associated with current {@link SipCallState}.
-     * Makes sense only for FAILED.
-     */
-    public XMPPError getError()
+    public JibriIq.FailureReason getFailureReason()
     {
-        XMPPErrorPE errorPe = getErrorPE();
-        return errorPe != null ? errorPe.getError() : null;
+        String failureReasonStr = getAttributeAsString(JibriIq.FAILURE_REASON_ATTR_NAME);
+        return JibriIq.FailureReason.parse(failureReasonStr);
     }
 
-    /**
-     * Gets <tt>{@link XMPPErrorPE}</tt> from the list of child packet
-     * extensions.
-     * @return {@link XMPPErrorPE} or <tt>null</tt> if not found.
-     */
-    private XMPPErrorPE getErrorPE()
+    public void setFailureReason(JibriIq.FailureReason failureReason)
     {
-        List<? extends ExtensionElement> errorPe
-            = getChildExtensionsOfType(XMPPErrorPE.class);
-
-        return (XMPPErrorPE) (!errorPe.isEmpty() ? errorPe.get(0) : null);
-    }
-
-    /**
-     * Sets <tt>XMPPError</tt> on this <tt>SipCallState</tt>. Doing this only
-     * makes sense for FAILED state. Otherwise the value will probably be
-     * ignored.
-     * @param error <tt>XMPPError</tt> to add error details to this
-     * <tt>SipCallState</tt> instance or <tt>null</tt> to have it removed.
-     */
-    public void setError(XMPPError error)
-    {
-        if (error != null)
+        if (failureReason != null)
         {
-            // Wrap and add XMPPError as packet extension
-            XMPPErrorPE errorPe = getErrorPE();
-            if (errorPe == null)
-            {
-                errorPe = new XMPPErrorPE(error);
-                addChildExtension(errorPe);
-            }
-            errorPe.setError(error);
-        }
-        else
-        {
-            // Remove error PE
-            getChildExtensions().remove(getErrorPE());
+            setAttribute(JibriIq.FAILURE_REASON_ATTR_NAME, failureReason.toString());
         }
     }
 }

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/SipCallState.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/SipCallState.java
@@ -102,12 +102,38 @@ public class SipCallState
         setAttribute(STATE_ATTRIBUTE, String.valueOf(status));
     }
 
+    /**
+     * Returns the session ID stored in this element
+     * @return the session ID
+     */
+    public String getSessionId()
+    {
+        return getAttributeAsString(JibriIq.SESSION_ID_ATTR_NAME);
+    }
+
+    /**
+     * Set the session ID for this recording status element
+     * @param sessionId the session ID
+     */
+    public void setSessionId(String sessionId)
+    {
+        setAttribute(JibriIq.SESSION_ID_ATTR_NAME, sessionId);
+    }
+
+    /**
+     * Get the failure reason in this status, or UNDEFINED if there isn't one
+     * @return the failure reason
+     */
     public JibriIq.FailureReason getFailureReason()
     {
         String failureReasonStr = getAttributeAsString(JibriIq.FAILURE_REASON_ATTR_NAME);
         return JibriIq.FailureReason.parse(failureReasonStr);
     }
 
+    /**
+     * Set the failure reason in this status
+     * @param failureReason the failure reason
+     */
     public void setFailureReason(JibriIq.FailureReason failureReason)
     {
         if (failureReason != null)


### PR DESCRIPTION
A summary of what was done here:
1) The 'status' values we pass between Jibri and Jicofo and Jicofo and the web were simplified:
a) States related to availability were removed.  We no longer communicate availability to the web client, the services (recording/live streaming) are enabled or disabled in the client and Jicofo will deny/fail to execute requests if no Jibris are available.
b) States that were actually temporary conditions, and not states (such as 'error' or 'busy') were shifted into a `FailureReason` value which can accompany the `OFF` state.  
c) The only states now are `ON`, `OFF`, and `PENDING`.

2) XMPPError was removed in favor of using `FailureReason`.  XMPPError would only show up in ErrorIQ messages, which can only be sent as responses (not new IQs), and Jibri needs to send new IQ messages after it replies to the initial request with status updates.

3) A session id was added to distinguish a unique Jibri session.  This makes debugging a lot easier, but also paves the way for potentially duplicate, parallel services running at once (for example, 2 live streams in a single call).

4) The RecordingMode has been added to the RecordingStatus.  Since we no longer have only a single service (file recording OR live stream) configured, clients other than the one who started the service need to know which service type is being started so they can display the proper label in the UI.

This will have some accompanying changes in Jicofo and Jibri as well, don't merge it yet but please take a look.

