### PR TITLE
Pass username on xmpp conn.login.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/LoginByPasswordStrategy.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/LoginByPasswordStrategy.java
@@ -96,7 +96,8 @@ public class LoginByPasswordStrategy
     public boolean login(AbstractXMPPConnection connection, EntityFullJid jid)
         throws XMPPException, InterruptedException, IOException, SmackException
     {
-        connection.login(jid.asEntityBareJidString(), password, jid.getResourceOrEmpty());
+        connection.login(
+            jid.getLocalpart(), password, jid.getResourceOrEmpty());
         return true;
     }
 


### PR DESCRIPTION
We need to pass username, not the bare jid when we call connection.login
.