### PR TITLE
Workaround for HiDPI support on Linux.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -872,6 +872,7 @@
             <sysproperty key="user.language" value="${user.language}" />
             <sysproperty key="user.country" value="${user.country}" />
             <sysproperty key="user.variant" value="${user.variant}" />
+            <sysproperty key="sun.java2d.uiScale" value="2" />
 
             <!-- make sure that we automatically enable system.out when running
                  Jitsi from Ant-->

--- a/src/net/java/sip/communicator/impl/gui/UIServiceImpl.java
+++ b/src/net/java/sip/communicator/impl/gui/UIServiceImpl.java
@@ -866,7 +866,8 @@ public class UIServiceImpl
          * Attempt to use the OS-native LookAndFeel instead of
          * SIPCommLookAndFeel.
          */
-        String laf = UIManager.getSystemLookAndFeelClassName();
+        // https://bugs.openjdk.java.net/browse/JDK-8058742
+        String laf = UIManager.getCrossPlatformLookAndFeelClassName();
         boolean lafIsSet = false;
 
         /*


### PR DESCRIPTION
It looks like the GtkLookAndFeel won't play nice with HiDPI graphics:

https://bugs.openjdk.java.net/browse/JDK-8055212
https://bugs.openjdk.java.net/browse/JDK-8058742

I don't know what the best approach to permanently fix this, but a
workaround is to use Java >= 9 that is HiDPI aware and the Motif look
and feel.