### PR TITLE
Remove namespace from ContentPacketExtension

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/ContentPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jingle/ContentPacketExtension.java
@@ -37,7 +37,7 @@ public class ContentPacketExtension extends AbstractPacketExtension
     /**
      * The namespace of the "content" element
      */
-    public static final String NAMESPACE = "urn:xmpp:jingle:1";
+    public static final String NAMESPACE = null;
 
     /**
      * The name of the "creator" argument.


### PR DESCRIPTION
This commit sets the namespace of the ContentPacketExtension to null. This was causing issues when parsing the jingle session-initiate message with stanza.io. The namespace was being set on content elements inside a group which stanza.io would fail to parse.

According the group XEP there usually isn't a namespace on the content elements (https://xmpp.org/extensions/xep-0338.html), and the namespace currently doesn't show up on the content elements inside the jingle element in the session-initiate message. (smack 4.2 might be doing something smart to remove a child element's namespace if it is the same as the parent).

More details in this discussion: https://community.jitsi.org/t/jitsi-dev-custom-client-fails-to-parse-jingle-session-initiate-with-new-jicofo/13992

Ran tests in jitsi-videobridge, jicofo, jicoco, and jigasi and all passed.