### PR TITLE
remove usage of DataObject in ChatRoomMemberJabberImpl

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomMemberJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomMemberJabberImpl.java
@@ -35,7 +35,6 @@ import org.jxmpp.jid.parts.Resourcepart;
  * @author Emil Ivov
  */
 public class ChatRoomMemberJabberImpl
-    extends DataObject
     implements JabberChatRoomMember
 {
     /**


### PR DESCRIPTION
not required anymore in Jigasi with recent changes to https://github.com/jitsi/jigasi/pull/106