### PR TITLE
FIX: Don't start the Smack Debugger UI by default.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/JabberActivator.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/JabberActivator.java
@@ -152,7 +152,6 @@ public class JabberActivator
      */
     public void start(BundleContext context) throws Exception
     {
-        SmackConfiguration.DEBUG = true;
         // Disables unused class, throwing some errors on login (disco-info)
         SmackConfiguration.addDisabledSmackClass(
             "org.jivesoftware.smackx.httpfileupload.HttpFileUploadManager");


### PR DESCRIPTION
This seems to be a leftover from earlier development. It causes the Smack debugger UI to
instantiate, which is often quite undesirable. As this code is reused on server components,
(eg jigasi), it can cause startup problems on headless environments too.