### PR TITLE
Let JRE be selected via shell variable on debian

### DIFF
--- a/resources/install/debian/jitsi.sh.tmpl
+++ b/resources/install/debian/jitsi.sh.tmpl
@@ -25,7 +25,11 @@ if $show_splash ; then
     SPLASH_ARG="-splash:splash.gif"
 fi
 
-javabin=`which java`
+if [ -z "$JITSI_JRE_HOME" ] ; then
+    javabin=`which java`
+else
+    javabin="$JITSI_JRE_HOME"/bin/java
+fi
 
 SCDIR=/usr/share/_PACKAGE_NAME_
 JITSI_COMMON_DIR=/usr/share/_PACKAGE_NAME_-common


### PR DESCRIPTION
An issue with openjdk 10 prevents jitsi from running on debian derivatives (including ubuntu bionic) where the system is configured
to run the java binary from openjdk 10 (see bug #530).  Unfortunately, this is the default for ubuntu bionic.

Let the user decide which jre to use with jitsi via shell variable JITSI_JRE_HOME, so that it is possible to install Java 8 on ubuntu and use it with jitsi, without having to make the whole system default to Java 8 or without forcing the user to edit the jitsi script.

For instance, with this patch, one can say:

JITSI_JRE_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre jitsi