### PR TITLE
Add registrar port to SIP invite request uri.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/sip/ProtocolProviderServiceSipImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/sip/ProtocolProviderServiceSipImpl.java
@@ -2493,6 +2493,14 @@ public class ProtocolProviderServiceSipImpl
             {
                 uriStr = user + "@"
                     + ((SipURI)src.getAddressOfRecord().getURI()).getHost();
+
+                int uriPort = 
+                    ((SipURI)src.getAddressOfRecord().getURI()).getPort();
+
+                if(uriPort != 5060) {
+                    uriStr = uriStr + ":" + String.valueOf(uriPort);
+                }
+                
             }
 
             //else this could only be a host ... but this should work as is.


### PR DESCRIPTION
If SIP registrar is running on a non standard port, calls that are placed by just dialing the "phone number" will fail. I think #363 was about same the problem. The reason is that port number of the registrar is not appended to the request uri.