### PR TITLE
overhaul the jibri status presence extension

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/AbstractPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/AbstractPacketExtension.java
@@ -265,6 +265,24 @@ public abstract class AbstractPacketExtension
     }
 
     /**
+     * Gets the first extension present of the given type
+     * @param type the type of extension to get
+     * @return the first instance of an extension of type T we find, or null if there is none
+     */
+    public <T extends ExtensionElement> T getChildExtension(Class<T> type)
+    {
+        List<T> childExts = getChildExtensionsOfType(type);
+        if (!childExts.isEmpty())
+        {
+            return childExts.get(0);
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    /**
      * Removes all occurrences of an extension element from the list of child
      * extensions.
      * @param childExtension the child extension to remove.

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/AbstractPacketExtension.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/AbstractPacketExtension.java
@@ -253,6 +253,18 @@ public abstract class AbstractPacketExtension
     }
 
     /**
+     * Add the given extension to the list of child extensions, but, if there already exists
+     * any child extensions of this type, remove them first.
+     * @param childExtension the extension to add
+     */
+    public void setChildExtension(ExtensionElement childExtension)
+    {
+        getChildExtensionsOfType(childExtension.getClass())
+            .forEach(this::removeChildExtension);
+        addChildExtension(childExtension);
+    }
+
+    /**
      * Removes all occurrences of an extension element from the list of child
      * extensions.
      * @param childExtension the child extension to remove.

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/health/HealthStatusPacketExt.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/health/HealthStatusPacketExt.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.java.sip.communicator.impl.protocol.jabber.extensions.health;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.AbstractPacketExtension;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.DefaultPacketExtensionProvider;
+import org.jitsi.util.StringUtils;
+import org.jivesoftware.smack.provider.ProviderManager;
+
+/**
+ * A generic extension for a component to represent its current health.
+ * NOTE: 'component' here does not refer to XMPP component, but any logical component of
+ * a system.
+ * One of:
+ * <li>healthy</li> - the component is healthy and can be considered as usable (other,
+ * component-specific factors should of course also be considered.  A component may be
+ * healthy but perhaps busy/unavailable to handle further requests at the moment).
+ * <li>unhealthy</li> - the component is not in a healthy state and should not be considered
+ * usable (despite what any other component-specific statuses may say).
+ *
+ * @author bbaldino
+ */
+public class HealthStatusPacketExt
+    extends AbstractPacketExtension
+{
+    /**
+     * XML namespace name for health check IQs.
+     */
+    final static public String NAMESPACE
+            = "http://jitsi.org/protocol/health";
+
+    public static final String ELEMENT_NAME = "health-status";
+
+    private static final String HEALTH_ATTRIBUTE = "status";
+
+    public HealthStatusPacketExt() { super(NAMESPACE, ELEMENT_NAME); }
+
+    static public void registerExtensionProvider()
+    {
+        ProviderManager.addExtensionProvider(
+                ELEMENT_NAME,
+                NAMESPACE,
+                new DefaultPacketExtensionProvider<>(HealthStatusPacketExt.class)
+        );
+    }
+
+    public Health getStatus()
+    {
+        return Health.parse(getAttributeAsString(HEALTH_ATTRIBUTE));
+    }
+
+    public void setStatus(Health health)
+    {
+        setAttribute(HEALTH_ATTRIBUTE, String.valueOf(health));
+    }
+
+    public enum Health
+    {
+        HEALTHY("healthy"),
+        UNHEALTHY("unhealthy"),
+        UNDEFINED("undefined");
+
+        private String health;
+
+        Health(String health) { this.health = health; }
+
+        @Override
+        public String toString()
+        {
+            return health;
+        }
+
+        /**
+         * Parses <tt>Health</tt> from given string.
+         *
+         * @param health the string representation of <tt>Health</tt>.
+         *
+         * @return <tt>Health</tt> value for given string or
+         *         {@link #UNDEFINED} if given string does not
+         *         reflect any of valid values.
+         */
+        public static Health parse(String health)
+        {
+            if (StringUtils.isNullOrEmpty(health))
+            {
+                return UNDEFINED;
+            }
+            try
+            {
+                return Health.valueOf(health.toUpperCase());
+            } catch (IllegalArgumentException e)
+            {
+                return UNDEFINED;
+            }
+        }
+    }
+
+}

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriBusyStatusPacketExt.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriBusyStatusPacketExt.java
@@ -1,0 +1,119 @@
+/*
+ * Jitsi, the OpenSource Java VoIP and Instant Messaging client.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.java.sip.communicator.impl.protocol.jabber.extensions.jibri;
+
+import net.java.sip.communicator.impl.protocol.jabber.extensions.AbstractPacketExtension;
+import net.java.sip.communicator.impl.protocol.jabber.extensions.DefaultPacketExtensionProvider;
+import org.jitsi.util.StringUtils;
+import org.jivesoftware.smack.provider.ProviderManager;
+
+/**
+ * Status extension included in MUC presence by Jibri to indicate it's status.
+ * One of:
+ * <li>idle</li> - the instance is idle and can be used for recording
+ * <li>busy</li> - the instance is currently recording or doing something very
+ *                 important and should not be disturbed
+ *
+ *
+ */
+public class JibriBusyStatusPacketExt
+    extends AbstractPacketExtension
+{
+    /**
+     * The namespace of this packet extension.
+     */
+    public static final String NAMESPACE = JibriIq.NAMESPACE;
+
+    /**
+     * XML element name of this packet extension.
+     */
+    public static final String ELEMENT_NAME = "busy-status";
+
+    private static final String STATUS_ATTRIBUTE = "status";
+
+    /**
+     * Creates new instance of <tt>VideoMutedExtension</tt>.
+     */
+    public JibriBusyStatusPacketExt()
+    {
+        super(NAMESPACE, ELEMENT_NAME);
+    }
+
+    static public void registerExtensionProvider()
+    {
+        ProviderManager.addExtensionProvider(
+                ELEMENT_NAME,
+                NAMESPACE,
+                new DefaultPacketExtensionProvider<>(JibriBusyStatusPacketExt.class)
+        );
+    }
+
+    public BusyStatus getStatus()
+    {
+        return BusyStatus.parse(getAttributeAsString(STATUS_ATTRIBUTE));
+    }
+
+    public void setStatus(BusyStatus status)
+    {
+        setAttribute(STATUS_ATTRIBUTE, String.valueOf(status));
+    }
+
+    public enum BusyStatus
+    {
+        IDLE("idle"),
+        BUSY("busy"),
+        UNDEFINED("undefined");
+
+        private String name;
+
+        BusyStatus(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+
+        /**
+         * Parses <tt>Status</tt> from given string.
+         *
+         * @param status the string representation of <tt>Status</tt>.
+         *
+         * @return <tt>Status</tt> value for given string or
+         *         {@link #UNDEFINED} if given string does not
+         *         reflect any of valid values.
+         */
+        public static BusyStatus parse(String status)
+        {
+            if (StringUtils.isNullOrEmpty(status))
+                return UNDEFINED;
+
+            try
+            {
+                return BusyStatus.valueOf(status.toUpperCase());
+            }
+            catch(IllegalArgumentException e)
+            {
+                return UNDEFINED;
+            }
+        }
+    }
+}

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriStatusPacketExt.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriStatusPacketExt.java
@@ -63,22 +63,10 @@ public class JibriStatusPacketExt
         );
     }
 
-    private <T extends ExtensionElement> T getFirstChildExtensionOrNull(Class<T> type)
-    {
-        List<T> childExts = getChildExtensionsOfType(type);
-        if (!childExts.isEmpty())
-        {
-            return childExts.get(0);
-        }
-        else
-        {
-            return null;
-        }
-    }
 
     public JibriBusyStatusPacketExt getBusyStatus()
     {
-        return getFirstChildExtensionOrNull(JibriBusyStatusPacketExt.class);
+        return getChildExtension(JibriBusyStatusPacketExt.class);
     }
 
     public void setBusyStatus(JibriBusyStatusPacketExt busyStatus)
@@ -88,7 +76,7 @@ public class JibriStatusPacketExt
 
     public HealthStatusPacketExt getHealthStatus()
     {
-        return getFirstChildExtensionOrNull(HealthStatusPacketExt.class);
+        return getChildExtension(HealthStatusPacketExt.class);
     }
 
     public void setHealthStatus(HealthStatusPacketExt healthStatus)

--- a/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriStatusPacketExt.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/extensions/jibri/JibriStatusPacketExt.java
@@ -19,18 +19,19 @@ package net.java.sip.communicator.impl.protocol.jabber.extensions.jibri;
 
 import net.java.sip.communicator.impl.protocol.jabber.extensions.*;
 
+import net.java.sip.communicator.impl.protocol.jabber.extensions.health.HealthStatusPacketExt;
 import org.jitsi.util.*;
 
+import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.provider.*;
 
+import java.util.List;
+
 /**
- * Status extension included in MUC presence by Jibri to indicate it's status.
- * One of:
- * <li>idle</li> - the instance is idle and can be used for recording
- * <li>busy</li> - the instance is currently recording or doing something very
- *                 important and should not be disturbed
- *
- *
+ * Status extension included in MUC presence by Jibri to indicate its overall status.
+ * Overall status is defined by two sub-extensions:
+ * {@link HealthStatusPacketExt} - whether or not this Jibri is healthy
+ * {@link JibriBusyStatusPacketExt} - whether or not this Jibri is busy
  */
 public class JibriStatusPacketExt
     extends AbstractPacketExtension
@@ -44,8 +45,6 @@ public class JibriStatusPacketExt
      * XML element name of this packet extension.
      */
     public static final String ELEMENT_NAME = "jibri-status";
-
-    private static final String STATUS_ATTRIBUTE = "status";
 
     /**
      * Creates new instance of <tt>VideoMutedExtension</tt>.
@@ -64,57 +63,48 @@ public class JibriStatusPacketExt
         );
     }
 
-    public Status getStatus()
+    private <T extends ExtensionElement> T getFirstChildExtensionOrNull(Class<T> type)
     {
-        return Status.parse(getAttributeAsString(STATUS_ATTRIBUTE));
+        List<T> childExts = getChildExtensionsOfType(type);
+        if (!childExts.isEmpty())
+        {
+            return childExts.get(0);
+        }
+        else
+        {
+            return null;
+        }
     }
 
-    public void setStatus(Status status)
+    public JibriBusyStatusPacketExt getBusyStatus()
     {
-        setAttribute(STATUS_ATTRIBUTE, String.valueOf(status));
+        return getFirstChildExtensionOrNull(JibriBusyStatusPacketExt.class);
     }
 
-    public enum Status
+    public void setBusyStatus(JibriBusyStatusPacketExt busyStatus)
     {
-        IDLE("idle"),
-        BUSY("busy"),
-        UNDEFINED("undefined");
+        setChildExtension(busyStatus);
+    }
 
-        private String name;
+    public HealthStatusPacketExt getHealthStatus()
+    {
+        return getFirstChildExtensionOrNull(HealthStatusPacketExt.class);
+    }
 
-        Status(String name)
-        {
-            this.name = name;
-        }
+    public void setHealthStatus(HealthStatusPacketExt healthStatus)
+    {
+        setChildExtension(healthStatus);
+    }
 
-        @Override
-        public String toString()
-        {
-            return name;
-        }
-
-        /**
-         * Parses <tt>Status</tt> from given string.
-         *
-         * @param status the string representation of <tt>Status</tt>.
-         *
-         * @return <tt>Status</tt> value for given string or
-         *         {@link #UNDEFINED} if given string does not
-         *         reflect any of valid values.
-         */
-        public static Status parse(String status)
-        {
-            if (StringUtils.isNullOrEmpty(status))
-                return UNDEFINED;
-
-            try
-            {
-                return Status.valueOf(status.toUpperCase());
-            }
-            catch(IllegalArgumentException e)
-            {
-                return UNDEFINED;
-            }
-        }
+    /**
+     * Provides a convenient helper to determine if this Jibri is available or not by looking at
+     * both the busy status and the health status.
+     * @return true if this Jibri should be considered available for use according to this presence, false
+     * otherwise
+     */
+    public boolean isAvailable()
+    {
+        return getHealthStatus().getStatus().equals(HealthStatusPacketExt.Health.HEALTHY) &&
+                getBusyStatus().getStatus().equals(JibriBusyStatusPacketExt.BusyStatus.IDLE);
     }
 }


### PR DESCRIPTION
jibri's status is now composed of 2 'sub statuses': its busy status
(whether or not this jibri is currently handling a request) and
its health status (whether or not this jibri has encountered and error
and needs intervention before it can handles requests again).