### PR TITLE
Port range update

### DIFF
--- a/m2/jitsi-desktoputil/pom.xml
+++ b/m2/jitsi-desktoputil/pom.xml
@@ -22,6 +22,21 @@
       <artifactId>laf-widget</artifactId>
       <version>4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.4</version>
+    </dependency>
     <!-- org.jitsi -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/m2/jitsi-neomedia/pom.xml
+++ b/m2/jitsi-neomedia/pom.xml
@@ -17,6 +17,26 @@
   <name>jitsi-neomedia</name>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.18</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>4.4</version>
+    </dependency>
     <!-- org.jitsi -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetDesktopSharingClientJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetDesktopSharingClientJabberImpl.java
@@ -214,7 +214,7 @@ public class OperationSetDesktopSharingClientJabberImpl
                 }
                 else
                 {
-                    addAddDeferredRemoteControlPeer(callPeerID);
+                    addAddDeferredRemoteControlPeer(callPeerID.toString());
                 }
             }
         }

--- a/src/net/java/sip/communicator/service/protocol/media/TransportManager.java
+++ b/src/net/java/sip/communicator/service/protocol/media/TransportManager.java
@@ -331,10 +331,38 @@ public abstract class TransportManager<U extends MediaAwareCallPeer<?, ?, ?>>
         PortTracker portTracker = getPortTracker(mediaType);
 
         //create the RTP socket.
-        DatagramSocket rtpSocket = null;
+        DatagramSocket rtpSocket
+            = createDatagramSocket(portTracker, localHostForPeer);
+
+        //create the RTCP socket, preferably on the port following our RTP one.
+        DatagramSocket rtcpSocket
+            = createDatagramSocket(portTracker, localHostForPeer);
+
+        return new DefaultStreamConnector(rtpSocket, rtcpSocket);
+    }
+
+    /**
+     * Creates <tt>DatagramSocket</tt> bind to <tt>localHostForPeer</tt>,
+     * used the port numbers provided by <tt>portTracker</tt> and update it with
+     * the result socket port so we do not try to bind to occupied ports.
+     *
+     * @param portTracker the port tracker.
+     * @param localHostForPeer the address to bind to.
+     * @return the newly created datagram socket.
+     * @throws OperationFailedException if we fail to create the socket.
+     */
+    private DatagramSocket createDatagramSocket(
+        PortTracker portTracker, InetAddress localHostForPeer)
+        throws OperationFailedException
+    {
+        NetworkAddressManagerService nam
+            = ProtocolMediaActivator.getNetworkAddressManagerService();
+
+        //create the socket.
+        DatagramSocket socket;
         try
         {
-            rtpSocket = nam.createDatagramSocket(
+            socket = nam.createDatagramSocket(
                 localHostForPeer, portTracker.getPort(),
                 portTracker.getMinPort(), portTracker.getMaxPort());
         }
@@ -346,29 +374,9 @@ public abstract class TransportManager<U extends MediaAwareCallPeer<?, ?, ?>>
         }
 
         //make sure that next time we don't try to bind on occupied ports
-        //also, refuse validation in case someone set the tracker range to 1
-        portTracker.setNextPort( rtpSocket.getLocalPort() + 1, false);
+        portTracker.setNextPort(socket.getLocalPort() + 1);
 
-        //create the RTCP socket, preferably on the port following our RTP one.
-        DatagramSocket rtcpSocket = null;
-        try
-        {
-            rtcpSocket = nam.createDatagramSocket(
-                localHostForPeer, portTracker.getPort(),
-                portTracker.getMinPort(), portTracker.getMaxPort());
-        }
-        catch (Exception exc)
-        {
-           throw new OperationFailedException(
-                "Failed to allocate the network ports necessary for the call.",
-                OperationFailedException.INTERNAL_ERROR,
-                exc);
-        }
-
-        //make sure that next time we don't try to bind on occupied ports
-        portTracker.setNextPort( rtcpSocket.getLocalPort() + 1);
-
-        return new DefaultStreamConnector(rtpSocket, rtcpSocket);
+        return socket;
     }
 
     /**

--- a/src/net/java/sip/communicator/util/PortTracker.java
+++ b/src/net/java/sip/communicator/util/PortTracker.java
@@ -137,30 +137,6 @@ public class PortTracker
     }
 
     /**
-     * Sets the next port to specified value unless allowing the caller to
-     * request validation and force the port into the range that this tracker
-     * operates in.
-     *
-     * @param nextPort the next port we'd like this tracker to return.
-     * @param validate determines whether this tracker should bring the new
-     * value into its current range.
-     */
-    public void setNextPort(int nextPort, boolean  validate)
-    {
-        /*
-         * Make sure that nextPort is within the specified range unless
-         */
-        if ((nextPort < minPort || nextPort > maxPort ) && validate)
-        {
-            port = minPort;
-        }
-        else
-        {
-            this.port = nextPort;
-        }
-    }
-
-    /**
      * Sets the next port to specified value unless it is outside the range that
      * this tracker operates in, in which case it sets it to the minimal
      * possible.
@@ -169,7 +145,17 @@ public class PortTracker
      */
     public void setNextPort(int nextPort)
     {
-        setNextPort(nextPort, true);
+        /*
+         * Make sure that nextPort is within the specified range unless
+         */
+        if ((nextPort < minPort || nextPort > maxPort ))
+        {
+            port = minPort;
+        }
+        else
+        {
+            this.port = nextPort;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR just removes the method `public void setNextPort(int nextPort, boolean  validate)` and handling of the validate param. 

That param was added with the comment: "also, refuse validation in case someone set the tracker range to 1". But we see problems with this code in jigasi and its healthcheck.

Simple test revealed the problem, we change the port in port tracker twice when we create a StreamConnector, the first one used to not validate the port and if it happened that we increment the port over the desired range when not validating, the next call of getting the port will return a port outside the range and the execution will fail with an exception: `IllegalArgumentException: preferredPort (20001) must be between minPort (10000) and maxPort (20000)`.