### PR TITLE
Use GTK2.2 to start jitsi

### DIFF
--- a/resources/install/build.xml
+++ b/resources/install/build.xml
@@ -2392,7 +2392,7 @@
             if="application.home.dirname">
         <replace file="${debianize.dir}/sh/${package.name}"
              token="net.java.sip.communicator.launcher.SIPCommunicator"
-             value="-Dnet.java.sip.communicator.SC_HOME_DIR_NAME=${application.home.dirname} net.java.sip.communicator.launcher.SIPCommunicator"/>
+             value="-Dnet.java.sip.communicator.SC_HOME_DIR_NAME=${application.home.dirname} -Djdk.gtk.version=2.2 net.java.sip.communicator.launcher.SIPCommunicator"/>
     </target>
 
     <target name="-deb-control-file"

--- a/resources/install/debian/jitsi.sh.tmpl
+++ b/resources/install/debian/jitsi.sh.tmpl
@@ -33,7 +33,7 @@ LIBPATH=$SCDIR/lib
 CLASSPATH=/usr/share/java/org.apache.felix.framework.jar:/usr/share/java/org.apache.felix.main.jar:$SCDIR/sc-bundles/dnsjava.jar:$SCDIR/sc-bundles/sc-launcher.jar:$JITSI_COMMON_DIR/util.jar/launchutils.jar:$LIBPATH
 FELIX_CONFIG=$LIBPATH/felix.client.run.properties
 LOG_CONFIG=$LIBPATH/logging.properties
-COMMAND="$javabin $CLIENTARGS -classpath $CLASSPATH -Djna.library.path=/usr/lib/jni -Dfelix.config.properties=file:$FELIX_CONFIG -Djava.util.logging.config.file=$LOG_CONFIG $SPLASH_ARG net.java.sip.communicator.launcher.SIPCommunicator"
+COMMAND="$javabin $CLIENTARGS -classpath $CLASSPATH -Djna.library.path=/usr/lib/jni -Dfelix.config.properties=file:$FELIX_CONFIG -Djava.util.logging.config.file=$LOG_CONFIG $SPLASH_ARG -Djdk.gtk.version=2.2 net.java.sip.communicator.launcher.SIPCommunicator"
 
 # set add LIBPATH to LD_LIBRARY_PATH for any sc natives (e.g. jmf .so's)
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/jni"

--- a/resources/install/generic/run.sh
+++ b/resources/install/generic/run.sh
@@ -12,4 +12,4 @@ then
 fi
 
 export PATH=$PATH:native
-java $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=native -Dfelix.config.properties=file:./lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator
+java $CLIENTARGS -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/util.jar:lib/" -Djava.library.path=native -Dfelix.config.properties=file:./lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties -Djdk.gtk.version=2.2 net.java.sip.communicator.launcher.SIPCommunicator

--- a/resources/install/linux/run.sh
+++ b/resources/install/linux/run.sh
@@ -2,4 +2,4 @@ mkdir -p $HOME/.sip-communicator/log
 
 export PATH=$PATH:native
 export JAVA_HOME=jre
-${JAVA_HOME}/bin/java -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/dnsjava.jar:sc-bundles/util.jar:lib/" -Djna.library.path=native -Djava.library.path=native -Dfelix.config.properties=file:./lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties net.java.sip.communicator.launcher.SIPCommunicator
+${JAVA_HOME}/bin/java -classpath "lib/felix.jar:sc-bundles/sc-launcher.jar:sc-bundles/dnsjava.jar:sc-bundles/util.jar:lib/" -Djna.library.path=native -Djava.library.path=native -Dfelix.config.properties=file:./lib/felix.client.run.properties -Djava.util.logging.config.file=lib/logging.properties -Djdk.gtk.version=2.2 net.java.sip.communicator.launcher.SIPCommunicator


### PR DESCRIPTION
This patch is related to issue #549 

I grepped all the places where Jitsi can be started and added the -Djdk.gtk.version=2.2 to the command line to enforce usage of GTK2.2 which does not crash on my system.

Please check I didn't forget one.