### PR TITLE
slf4j to 1.8.0-beta2 (CVE-2018-8088)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -984,8 +984,8 @@
         <copy file="${lib.noinst}/guava-15.0.jar" tofile="${bundles.dest}/guava.jar"/>
         <copy file="${lib.noinst}/hsqldb.jar" tofile="${bundles.dest}/hsqldb.jar"/>
         <copy file="${lib.noinst}/irc-api-1.0.jar" tofile="${bundles.dest}/irc-api-1.0.jar"/>
-        <copy file="${lib.noinst}/slf4j-api-1.7.5.jar" tofile="${bundles.dest}/slf4j-api.jar"/>
-        <copy file="${lib.noinst}/slf4j-jdk14-1.7.5.jar" tofile="${bundles.dest}/slf4j-jdk14.jar"/>
+        <copy file="${lib.noinst}/slf4j-api-1.8.0-beta2.jar" tofile="${bundles.dest}/slf4j-api.jar"/>
+        <copy file="${lib.noinst}/slf4j-jdk14-1.8.0-beta2.jar" tofile="${bundles.dest}/slf4j-jdk14.jar"/>
         <copy file="${lib.noinst}/commons-codec-1.6.jar" tofile="${bundles.dest}/commons-codec.jar"/>
         <copy file="${lib.noinst}/commons-compress-1.15.jar" tofile="${bundles.dest}/commons-compress.jar"/>
         <copy file="${lib.noinst}/commons-lang3-3.1.jar" tofile="${bundles.dest}/commons-lang.jar"/>


### PR DESCRIPTION
slf4j to 1.8.0-beta2 (CVE-2018-8088)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088