### PR TITLE
Fixes exception "The Resourcepart must not be null" on xmpp muc join.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
@@ -1102,6 +1102,16 @@ public class ChatRoomJabberImpl
     {
         if(this.role == null)
         {
+            // If there is no nickname, there is no way to match anything.
+            // Sometimes while joining we receive the presence and dispatch
+            // the user role before nickname is stored in multiUserChat
+            // returning guest here is just for the event reporting the new
+            // role and that old is guest
+            if (multiUserChat.getNickname() == null)
+            {
+                return ChatRoomMemberRole.GUEST;
+            }
+
             Occupant o = multiUserChat.getOccupant(JidCreate.entityFullFrom(
                 multiUserChat.getRoom(), multiUserChat.getNickname()));
 


### PR DESCRIPTION
Sometimes while joining we receive the presence and dispatch the user
role before nickname is stored in multiUserChat. Returning guest is just
 for the event reporting the new role and that old is guest.

java.lang.IllegalArgumentException: The Resourcepart must not be null
        at org.jxmpp.jid.impl.AbstractJid.requireNonNull(AbstractJid.java:243)
        at org.jxmpp.jid.impl.LocalDomainAndResourcepartJid.<init>(LocalDomainAndResourcepartJid.java:49)
        at org.jxmpp.jid.impl.JidCreate.entityFullFrom(JidCreate.java:838)
        at net.java.sip.communicator.impl.protocol.jabber.ChatRoomJabberImpl.getUserRole(ChatRoomJabberImpl.java:1105)
        at net.java.sip.communicator.impl.protocol.jabber.ChatRoomJabberImpl.setLocalUserRole(ChatRoomJabberImpl.java:1135)
        at net.java.sip.communicator.impl.protocol.jabber.ChatRoomJabberImpl$ChatRoomPresenceListener.processOwnPresence(ChatRoomJabberImpl.java:3148)
        at net.java.sip.communicator.impl.protocol.jabber.ChatRoomJabberImpl$ChatRoomPresenceListener.processStanza(ChatRoomJabberImpl.java:3087)
        at org.jivesoftware.smack.AbstractXMPPConnection$5.run(AbstractXMPPConnection.java:1233)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)