### PR TITLE
Cleans connection references on stopping provider.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/CallPeerJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/CallPeerJabberImpl.java
@@ -1184,7 +1184,11 @@ public class CallPeerJabberImpl
             = new CoinPacketExtension(getCall().isConferenceFocus());
 
         sessionInfoIQ.addExtension(coinExt);
-        getProtocolProvider().getConnection().sendStanza(sessionInfoIQ);
+        XMPPConnection connection = getProtocolProvider().getConnection();
+        if (connection != null)
+        {
+            connection.sendStanza(sessionInfoIQ);
+        }
     }
 
     /**

--- a/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetPersistentPresenceJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/OperationSetPersistentPresenceJabberImpl.java
@@ -1165,13 +1165,22 @@ public class OperationSetPersistentPresenceJabberImpl
             }
             else if(evt.getNewState() == RegistrationState.REGISTERED)
             {
-                createContactPhotoPresenceListener();
+                JabberAccountIDImpl accountID
+                    = (JabberAccountIDImpl)parentProvider.getAccountID();
+                boolean isServerStoredInfoEnabled
+                    = !accountID.getAccountPropertyBoolean(
+                        ProtocolProviderServiceJabberImpl
+                            .IS_SERVER_STORED_INFO_DISABLED_PROPERTY, false);
 
-                // we cannot manipulate our vcards when using anonymous
-                if (!((JabberAccountIDImpl)parentProvider.getAccountID())
-                        .isAnonymousAuthUsed())
+                if (isServerStoredInfoEnabled)
                 {
-                    createAccountPhotoPresenceInterceptor();
+                    createContactPhotoPresenceListener();
+
+                    // we cannot manipulate our vcards when using anonymous
+                    if(!accountID.isAnonymousAuthUsed())
+                    {
+                        createAccountPhotoPresenceInterceptor();
+                    }
                 }
             }
             else if(evt.getNewState() == RegistrationState.UNREGISTERING)
@@ -1603,7 +1612,7 @@ public class OperationSetPersistentPresenceJabberImpl
                                 // make sure we are consinstent with equals.
                                 // We do this by comparing the unique resource
                                 // names. If this evaluates to 0 again, then we
-                                // can safely assume this presence object 
+                                // can safely assume this presence object
                                 // represents the same resource and by that the
                                 // same client.
                                 if(res == 0)

--- a/src/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
@@ -228,7 +228,7 @@ public class ProtocolProviderServiceJabberImpl
      * Property to disable server stored info retrieval and manipulation, as
      * contact and account info and also avatar retrieval.
      */
-    private static final String IS_SERVER_STORED_INFO_DISABLED_PROPERTY
+    public static final String IS_SERVER_STORED_INFO_DISABLED_PROPERTY
         = "SERVER_STORED_INFO_DISABLED";
 
     /**
@@ -1490,6 +1490,12 @@ public class ProtocolProviderServiceJabberImpl
                 connection.disconnect(unavailablePresence);
             } catch (Exception e)
             {}
+
+            if (debugger != null)
+            {
+                debugger.setConnection(null);
+                debugger = null;
+            }
 
             connectionListener = null;
             connection = null;

--- a/src/net/java/sip/communicator/impl/protocol/jabber/ScServiceDiscoveryManager.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ScServiceDiscoveryManager.java
@@ -85,7 +85,7 @@ public class ScServiceDiscoveryManager
     /**
      * The {@link XMPPConnection} that this manager is responsible for.
      */
-    private final XMPPConnection connection;
+    private XMPPConnection connection;
 
     /**
      * A local copy that we keep in sync with {@link ServiceDiscoveryManager}'s
@@ -655,6 +655,8 @@ public class ScServiceDiscoveryManager
     {
         if(retriever != null)
             retriever.stop();
+
+        this.connection = null;
     }
 
     /**

--- a/src/net/java/sip/communicator/impl/protocol/jabber/debugger/SmackPacketDebugger.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/debugger/SmackPacketDebugger.java
@@ -92,7 +92,7 @@ public class SmackPacketDebugger
             {
                 if(packetLogging.isLoggingEnabled(
                         PacketLoggingService.ProtocolName.JABBER)
-                    && packet != null && getSocket() != null)
+                    && packet != null)
                 {
                     Socket socket = getSocket();
                     if(remoteAddress == null)
@@ -114,7 +114,14 @@ public class SmackPacketDebugger
                     if (socket != null)
                     {
                         localPort = socket.getLocalPort();
-                        remotePort = connection.getPort();
+                    }
+                    if (connection != null)
+                    {
+                        int port = connection.getPort();
+                        if (port > 0)
+                        {
+                            remotePort = port;
+                        }
                     }
 
                     byte[] packetBytes;
@@ -227,7 +234,15 @@ public class SmackPacketDebugger
                     if (socket != null)
                     {
                         localPort = socket.getLocalPort();
-                        remotePort = connection.getPort();
+                    }
+
+                    if (connection != null)
+                    {
+                        int port = connection.getPort();
+                        if (port > 0)
+                        {
+                            remotePort = port;
+                        }
                     }
 
                     byte[] packetBytes;
@@ -263,6 +278,11 @@ public class SmackPacketDebugger
 
     private Socket getSocket()
     {
+        if (this.connection == null)
+        {
+            return null;
+        }
+
         try
         {
             Field socket = connection.getClass().getField("socket");


### PR DESCRIPTION
Leaving connections is dangerous as smack many static weak maps of
connections and leaving a connection here makes a strong connection
between the key and the value and this prevents a lot of objects to be
garbage collected.
