### PR TITLE
Resources (Branding): Avoids repeating Info messages in the log.

### DIFF
--- a/src/net/java/sip/communicator/impl/resources/ResourceManagementServiceImpl.java
+++ b/src/net/java/sip/communicator/impl/resources/ResourceManagementServiceImpl.java
@@ -231,8 +231,6 @@ public class ResourceManagementServiceImpl
 
         if (path == null || path.length() == 0)
         {
-            if (logger.isInfoEnabled())
-                logger.info("Missing resource for key: " + urlKey);
             return null;
         }
         return getImageURLForPath(path);


### PR DESCRIPTION
This change avoids the Info message `Missing resource for key: service.gui.MAIN_WINDOW_BACKGROUND` which is printed in the log file, every time when the user moves the cursor over one of the Dial panels.