### PR TITLE
Apache Felix (OSGi): Allow X11 to the Java Classloader.

### DIFF
--- a/lib/felix.client.run.properties
+++ b/lib/felix.client.run.properties
@@ -19,6 +19,7 @@ org.osgi.framework.system.packages.extra= \
  quicktime.std.sg, \
  quicktime.util, \
  sun.awt.shell, \
+ sun.awt.X11, \
  sun.lwawt, \
  sun.lwawt.macosx, \
  sun.misc, \


### PR DESCRIPTION
Otherwise, sometimes (not reproducible), JAWT Rendering is not able to load the class sun.awt.x11.XErrorHandlerUtil. Requires the latest LibJitsi, see jitsi/libjitsi#514.