### PR TITLE
Minimizes sync block trying to fix a deadlock.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
@@ -1551,32 +1551,32 @@ public class ProtocolProviderServiceJabberImpl
      */
     public void unregisterInternal(boolean fireEvent, boolean userRequest)
     {
+        if(fireEvent)
+        {
+            eventDuringLogin = null;
+            fireRegistrationStateChanged(
+                getRegistrationState()
+                , RegistrationState.UNREGISTERING
+                , RegistrationStateChangeEvent.REASON_NOT_SPECIFIED
+                , null
+                , userRequest);
+        }
+
         synchronized(initializationLock)
         {
-            if(fireEvent)
-            {
-                eventDuringLogin = null;
-                fireRegistrationStateChanged(
-                    getRegistrationState()
-                    , RegistrationState.UNREGISTERING
-                    , RegistrationStateChangeEvent.REASON_NOT_SPECIFIED
-                    , null
-                    , userRequest);
-            }
-
             disconnectAndCleanConnection();
+        }
 
-            RegistrationState currRegState = getRegistrationState();
+        RegistrationState currRegState = getRegistrationState();
 
-            if(fireEvent)
-            {
-                eventDuringLogin = null;
-                fireRegistrationStateChanged(
-                    currRegState,
-                    RegistrationState.UNREGISTERED,
-                    RegistrationStateChangeEvent.REASON_USER_REQUEST, null,
-                    userRequest);
-            }
+        if(fireEvent)
+        {
+            eventDuringLogin = null;
+            fireRegistrationStateChanged(
+                currRegState,
+                RegistrationState.UNREGISTERED,
+                RegistrationStateChangeEvent.REASON_USER_REQUEST, null,
+                userRequest);
         }
     }
 


### PR DESCRIPTION
```
"qtp802921335-29":
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.registrationStateChanged(PPReconnectWrapper.java:148)
	- waiting to lock <0x000000070068f518> (a java.lang.Object)
	at net.java.sip.communicator.service.protocol.AbstractProtocolProviderService.fireRegistrationStateChanged(AbstractProtocolProviderService.java:187)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregisterInternal(ProtocolProviderServiceJabberImpl.java:1574)
	- locked <0x0000000700267760> (a java.lang.Object)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregister(ProtocolProviderServiceJabberImpl.java:1536)
	at org.jitsi.jigasi.xmpp.CallControlMucActivator.removeCallControlMucAccount(CallControlMucActivator.java:494)
	- locked <0x0000000700486e80> (a java.lang.Class for org.jitsi.jigasi.xmpp.CallControlMucActivator)
	at org.jitsi.jigasi.rest.HandlerImpl.doHandleConfigureMucRequest(HandlerImpl.java:463)
	at org.jitsi.jigasi.rest.HandlerImpl.handleJSON(HandlerImpl.java:267)
	at org.jitsi.rest.AbstractJSONHandler.handle(AbstractJSONHandler.java:337)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:505)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:786)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:743)
	at java.lang.Thread.run(Thread.java:748)
"Reconnect timer p:Jabber:jigasi@auth.example.com@10.20.3.220":
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregisterInternal(ProtocolProviderServiceJabberImpl.java:1556)
	- waiting to lock <0x0000000700267760> (a java.lang.Object)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregisterInternal(ProtocolProviderServiceJabberImpl.java:1545)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.unregister(ProtocolProviderServiceJabberImpl.java:1527)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.unregister(PPReconnectWrapper.java:367)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.reconnect(PPReconnectWrapper.java:350)
	- locked <0x000000070068f518> (a java.lang.Object)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper.registrationStateChanged(PPReconnectWrapper.java:221)
	- locked <0x000000070068f518> (a java.lang.Object)
	at net.java.sip.communicator.service.protocol.AbstractProtocolProviderService.fireRegistrationStateChanged(AbstractProtocolProviderService.java:187)
	at net.java.sip.communicator.service.protocol.AbstractProtocolProviderService.fireRegistrationStateChanged(AbstractProtocolProviderService.java:141)
	at net.java.sip.communicator.impl.protocol.jabber.ProtocolProviderServiceJabberImpl.register(ProtocolProviderServiceJabberImpl.java:532)
	- locked <0x0000000700268358> (a java.lang.Object)
	at net.java.sip.communicator.plugin.reconnectplugin.PPReconnectWrapper$ReconnectTask.run(PPReconnectWrapper.java:454)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)

Found 1 deadlock.
```