### PR TITLE
Add support for building snaps & Ubuntu Core appliance image

### DIFF
--- a/scripts/jicofo.sh
+++ b/scripts/jicofo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+mkdir -p $HOME/jitsi
+touch $HOME/jitsi/jicofo.log
+chmod $HOME/777 jitsi
+chmod $HOME/666 jitsi/jicofo.log
+
+export JICOFO_LOGFILE="jitsi/jicofo.log"
+export JICOFO_HOST="localhost"
+export JICOFO_HOSTNAME="jitsi"
+export JICOFO_PORT"5347"
+export JICOFO_SECRET="bcWOatTQ"
+export JICOFO_AUTH_USER="focus"
+export JICOFO_AUTH_DOMAIN="auth.virt"
+export JICOFO_AUTH_PASSWORD="CLNUy0om"
+
+$SNAP/usr/share/jicofo/jicofo.sh --host="$JICOFO_HOST" --domain="$JICOFO_HOST" --port="$JICOFO_PORT" --secret="$JICOFO_SECRET" --user_name="$JICOFO_AUTH_USER" --user_domain="$JICOFO_AUTH_DOMAIN" --user_password="$JICOFO_AUTH_PASSWORD" "$JICOFO_OPTS" | tee -a "${JICOFO_LOGFILE}"

--- a/scripts/jitsi-videobridge.sh
+++ b/scripts/jitsi-videobridge.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+mkdir -p $HOME/jitsi
+touch $HOME/jitsi/jvb.log
+chmod 777 $HOME/jitsi
+chmod 666 $HOME/jitsi/jvb.log
+
+
+#export JAVA_HOME=$SNAP/usr/lib/jvm/java-11-openjdk-amd64
+#export PATH=$JAVA_HOME/bin:$PATH
+
+export JITSI_LOGFILE="$HOME/jitsi/jvb.log"
+export JVB_HOSTNAME="jitsi"
+export JVB_PORT="5347"
+export JVB_SECRET="Mwqz0j5J"
+export JVB_OPTS="--apis=rest,xmpp"
+export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=jitsi -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties JITSI_LOGFILE: jitsi/jvb.log"
+
+"$SNAP/usr/share/jitsi-videobridge/jvb.sh" --host="${JVB_HOST:-localhost}" --domain="${JVB_HOSTNAME}" --port="${JVB_PORT}" --secret="${JVB_SECRET}" "${JVB_OPTS}" | tee -a "${JITSI_LOGFILE}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,96 @@
+name: jitsi
+version: "1.0"
+summary: Jitsi
+description: |
+  This is a snap of Jitsi
+
+grade: stable
+confinement: strict
+base: core18
+
+# might need certificate configuration
+
+parts:
+  jicofo:
+    plugin: dump
+    source: https://download.jitsi.org/jitsi/debian/jicofo_1.0-508-1_amd64.deb
+  jitsi-meet-prosody:
+    plugin: dump
+    source: https://download.jitsi.org/jitsi/debian/jitsi-meet-prosody_1.0.3729-1_all.deb
+  jitsi-meet-web:
+    plugin: dump
+    source: https://download.jitsi.org/jitsi/debian/jitsi-meet-web_1.0.3729-1_all.deb
+  jitsi-videobridge:
+    plugin: dump
+    source: https://download.jitsi.org/jitsi/debian/jitsi-videobridge_1126-1_amd64.deb
+  jitsi-meet-web-config:
+    plugin: dump
+    source: https://download.jitsi.org/jitsi/debian/jitsi-meet-web-config_1.0.3729-1_all.deb
+    override-pull: |
+      snapcraftctl pull
+      echo "jitsi" > etc/hostname
+      echo "127.0.0.1 localhost jitsi" > etc/hosts
+      #usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh
+
+    stage-packages:
+      - prosody
+      - lua-bitop
+      - lua-event
+      - lua-expat
+      - lua-filesystem
+      - lua-sec
+      - lua-socket
+      - lua5.2
+      - openjdk-8-jre-headless
+      - ca-certificates-java
+      - java-common
+
+  jitsi-scripts:
+    source: ./scripts
+    plugin: dump
+
+layout:
+  /etc/jitsi:
+    bind: $SNAP/etc/jitsi
+  #/var/log/jitsi:
+  #  bind: $SNAP_DATA/var/log/jitsi
+
+environment:
+  JVB_HOSTNAME: jitsi
+  JVB_PORT: 5347
+  JVB_SECRET: Mwqz0j5J
+  JVB_OPTS: --apis=rest,xmpp
+  JAVA_SYS_PROPS: -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=$HOME/jitsi -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties
+  JITSI_LOGFILE: $HOME/jitsi/jvb.log
+  JICOFO_LOGFILE: $HOME/jitsi/jicofo.log
+  JICOFO_HOST: localhost
+  JICOFO_HOSTNAME: jitsi
+  JICOFO_PORT: 5347
+  JICOFO_SECRET: bcWOatTQ
+  JICOFO_AUTH_USER: focus
+  JICOFO_AUTH_DOMAIN: auth.virt
+  JICOFO_AUTH_PASSWORD: CLNUy0om
+
+apps:
+  jitsi-videobridge:
+    command: jitsi-videobridge.sh
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind
+    environment:
+      JAVA_HOME: $SNAP/usr/lib/jvm/java-11-openjdk-amd64
+      PATH: $JAVA_HOME/bin:$PATH
+  jicofo:
+    command: jicofo.sh
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind
+    environment:
+      JAVA_HOME: $SNAP/usr/lib/jvm/java-11-openjdk-amd64
+      PATH: $JAVA_HOME/bin:$PATH


### PR DESCRIPTION

Hi folks,

Following up an email exchange with Emil, I'm filing this PR to request support for snaps, as a first step toward creating a Jitsi Ubuntu Core appliance.

This PR consists of:

* snapcraft.yaml that is used to build the snap using the snapcraft command-line tool (https://snapcraft.io/docs/snapcraft-overview).
* jitsi-videobridge.sh and jicofo.sh wrapper scripts (bash) that set the environment for the service to run (extrapolated from the systemd service).

The layout is:

* snap/snapcraft.yaml
* scripts/[jitsi-videobridge, jicofo].sh

I built Jitsi by using existing deb files as sources and then extracting them into the snap, and adding the necessary runtime requirements, like java, prosody, lua, etc. You can of course build from sources. I did this as it was a faster way to create a proof of concept for you guys to work with.

I also used the "secrets" generated on first run, to have the service start, but of course, you can also customize this as you see fit.

I left a few small commented parts out to help you better understand some of the logic I used for the creation of the snap. For instance, you can configure environment for the snap applications using the `environment` keyword (necessary for Java HOME) in the snapcraft.yaml - optionally, one woild do this through the startup script. `Layout` is another feature that lets you make elements in the snap environment accessible from "external" paths, which may sometimes be hard-coded into binaries.

The next steps would be for you to build and test the snap of your own. You can build the snap using snapcraft locally, using our remote build feature that builds in launchpad, or use our online Build Services that can hook up GitHub repositories. The last two options also allow you to build for six architectures, which can be quite useful for building Jitsi for IoT devices, Pis, etc.

https://snapcraft.io/blog/handy-snapcraft-features-remote-build
https://snapcraft.io/build

Once you're comfortable with the syntax, you can then push the snap to the Snap Store.

This would entail three steps - registering a dev account, registering the Jitsi snap name, and then pushing the application to the store.

https://snapcraft.io/docs/releasing-to-the-snap-store

We can help you promote Jitsi, and then we can work on seeding the snap into the Ubuntu Core appliance image.

Let me know if you have any questions.