### PR TITLE
Updates debian dependencies.

### DIFF
--- a/resources/install/debian/control.tmpl
+++ b/resources/install/debian/control.tmpl
@@ -68,6 +68,7 @@ Recommends: libappindicator1,
  libavfilter6 | libavfilter-extra6 | libavfilter-ffmpeg5,
  libavutil55 | libavutil-ffmpeg54,
  libswscale4 | libswscale-ffmpeg3,
+ openjdk-8-jre, | java8-runtime,
  jitsi-archive-keyring
 Description: VoIP and Instant Messaging client
  _APP_NAME_ is an application that allows you to do audio/video


### PR DESCRIPTION
java.lang.UnsatisfiedLinkError: no splashscreen in java.library.path
	at net.java.sip.communicator.impl.splashscreen.SplashScreenActivator.start(SplashScreenActivator.java:70)
is printed otherwise. However, because Jitsi Desktop starts even with this error, the splash screen is optional. Consequently, a headless Java environment is sufficient and the non-headless Java environment is optional. Therefore, the non-headless is not in Depends but in Recommends.