### PR TITLE
Extend OperationFailedException and lobby support

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
@@ -244,6 +244,12 @@ public class ChatRoomJabberImpl
     {
         Jid lobbyJid = null;
 
+        /**
+         * This method is used to get a Jid that represents the lobby room that the user joins when trying
+         * to join a meeting with lobby enabled. The custom <lobbyroom></lobbyroom> field is added to the error
+         * in case the user is not yet a member of the meeting that was joined initially.
+         */
+
         try
         {
             if (packet != null)
@@ -775,7 +781,14 @@ public class ChatRoomJabberImpl
 
                     Jid lobbyJid = getLobbyJidFromPacket(stanzaError);
 
-                    dataObject.setData("lobbyroomjid", lobbyJid);
+                    if (lobbyJid != null)
+                    {
+                        dataObject.setData("lobbyroomjid", lobbyJid);
+                    }
+                    else
+                    {
+                        logger.warn("No lobby Jid! But registration required!");
+                    }
                 }
 
                 throw operationFailedException;

--- a/src/net/java/sip/communicator/service/protocol/OperationFailedException.java
+++ b/src/net/java/sip/communicator/service/protocol/OperationFailedException.java
@@ -17,6 +17,8 @@
  */
 package net.java.sip.communicator.service.protocol;
 
+import net.java.sip.communicator.util.*;
+
 /**
  * <tt>OperationFailedException</tt> indicates an exception that occurred in the
  * API.
@@ -161,6 +163,11 @@ public class OperationFailedException
     private final int errorCode;
 
     /**
+     * Map that can be used for additional info about the failure.
+     */
+    private final DataObject dataObject = new DataObject();
+
+    /**
      * Creates an exception with the specified error message and error code.
      * @param message A message containing details on the error that caused the
      * exception
@@ -198,5 +205,14 @@ public class OperationFailedException
     public int getErrorCode()
     {
         return errorCode;
+    }
+
+    /**
+     * Obtain the <tt>DataObject</tt> that may contain additional info.
+     *
+     * @return <tt>DataObject</tt> additional info.
+     */
+    public DataObject getDataObject() {
+        return dataObject;
     }
 }


### PR DESCRIPTION
This PR adds a DataObject to the OperationFailedException to be used for additional information when needed.