### PR TITLE
Add room destroyed event for local user

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
@@ -227,7 +227,9 @@ public class ChatRoomJabberImpl
             new SmackSubjectUpdatedListener());
         multiUserChat.addMessageListener(new SmackMessageListener());
         multiUserChat.addParticipantStatusListener(new MemberListener());
-        multiUserChat.addUserStatusListener(new UserListener());
+
+        UserListener userListener = new UserListener(this);
+        multiUserChat.addUserStatusListener(userListener);
         multiUserChat.addPresenceInterceptor(new PresenceInterceptor());
 
         this.provider.getConnection().addAsyncStanzaListener(
@@ -2522,10 +2524,38 @@ public class ChatRoomJabberImpl
      */
     private class UserListener implements UserStatusListener
     {
-        @Override
-        public void roomDestroyed(MultiUserChat multiUserChat, String s)
+        /**
+         * Used in case <tt>ChatRoomJabberImpl</tt> is not available
+         * on roomDestroyed.
+         */
+        private ChatRoomJabberImpl chatRoomJabberImpl = null;
+
+        /**
+         * Constructs new instance of <tt>UserListener</tt>.
+         *
+         * @param chatRoomJabber
+         */
+        public UserListener(ChatRoomJabberImpl chatRoomJabber)
         {
-            throw new UnsupportedOperationException();
+            this.chatRoomJabberImpl = chatRoomJabber;
+        }
+
+        /**
+         * Called when a room was destroyed. This means that the room you have
+         * joined is no longer available.
+         *
+         * @param multiUserChat <tt>MultiUserChat</tt>.
+         * @param the reason why room was destroyed.
+         */
+        @Override
+        public void roomDestroyed(MultiUserChat multiUserChat, String reason)
+        {
+            opSetMuc.fireLocalUserPresenceEvent(
+                    this.chatRoomJabberImpl,
+                    LocalUserChatRoomPresenceChangeEvent.LOCAL_USER_ROOM_DESTROYED,
+                    reason);
+
+            this.chatRoomJabberImpl = null;
         }
 
         /**

--- a/src/net/java/sip/communicator/service/protocol/event/LocalUserChatRoomPresenceChangeEvent.java
+++ b/src/net/java/sip/communicator/service/protocol/event/LocalUserChatRoomPresenceChangeEvent.java
@@ -68,6 +68,12 @@ public class LocalUserChatRoomPresenceChangeEvent
     public static final String LOCAL_USER_DROPPED = "LocalUserDropped";
 
     /**
+     * Indicates that this event was triggered as a result of the local
+     * participant no longer being in the initially valid room.
+     */
+    public static final String LOCAL_USER_ROOM_DESTROYED = "LocalUserRoomDestroyed";
+
+    /**
      * The <tt>ChatRoom</tt> to which the change is related.
      */
     private ChatRoom chatRoom = null;


### PR DESCRIPTION
This PR adds the LOCAL_USER_ROOM_DESTROYED event to notify the current user that the joined room is no more.