### PR TITLE
fix: Removes an exception when calling leave on xmpp chat room.

### DIFF
--- a/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
+++ b/src/net/java/sip/communicator/impl/protocol/jabber/ChatRoomJabberImpl.java
@@ -1031,7 +1031,8 @@ public class ChatRoomJabberImpl
         {
             // if we are already disconnected
             // leave maybe called from gui when closing chat window
-            if(connection != null && connection.isConnected())
+            // skip leave if not joined, this is in case of an error, but we call leave to clear listeners and such
+            if(connection != null && connection.isConnected() && multiUserChat.isJoined())
                 multiUserChat.leave();
         }
         catch(Throwable e)


### PR DESCRIPTION
In case join throws an error like members only rooms (lobby and jigasi), we need to call leave of the room to clear listeners. This just removes an annoying not needed stack trace.