### PR TITLE
Update GitHub Actions to avoid `set-output` deprecation

### DIFF
--- a/resources/version.sh
+++ b/resources/version.sh
@@ -8,9 +8,9 @@ if [[ $MVNVER =~ $MVNVER_MATCHER ]]; then
   echo "MAJOR=${MAJOR}"
   echo "MINOR=${MINOR}"
   echo "SUFFIX=${SUFFIX}"
-  echo "::set-output name=jitsi_version_major::${MAJOR}"
-  echo "::set-output name=jitsi_version_minor::${MINOR}"
-  echo "::set-output name=jitsi_version_suffix::${SUFFIX}"
+  echo "jitsi_version_major=${MAJOR}" >> $GITHUB_OUTPUT
+  echo "jitsi_version_minor=${MINOR}" >> $GITHUB_OUTPUT
+  echo "jitsi_version_suffix=${SUFFIX}" >> $GITHUB_OUTPUT
 else
   echo "$MVNVER did not match $MVNVER_MATCHER"
   exit 1
@@ -18,15 +18,15 @@ fi;
 
 GITVER=`git describe --match Jitsi-[0-9.]* --long --dirty --always`
 echo "GITVER=${GITVER}"
-echo "::set-output name=jitsi_version_git::${GITVER}"
+echo "jitsi_version_git=${GITVER}" >> $GITHUB_OUTPUT
 GITVER_MATCHER="^((Jitsi-[0-9.]+)-([0-9]+)-)?([A-Za-z0-9-]+)$"
 if [[ $GITVER =~ $GITVER_MATCHER ]]; then
   NCOMMITS=${BASH_REMATCH[3]}
   HASH=${BASH_REMATCH[4]}
   echo "NCOMMITS=${NCOMMITS}"
   echo "HASH=${HASH}"
-  echo "::set-output name=jitsi_version_ncommits::${NCOMMITS}"
-  echo "::set-output name=jitsi_version_hash::${HASH}"
+  echo "jitsi_version_ncommits=${NCOMMITS}" >> $GITHUB_OUTPUT
+  echo "jitsi_version_hash=${HASH}" >> $GITHUB_OUTPUT
 else
   echo "$GITVER did not match $GITVER_MATCHER"
   exit 1
@@ -45,6 +45,6 @@ fi;
 echo "VERSION_SHORT=${VERSION_SHORT}"
 echo "VERSION_FULL=${VERSION_FULL}"
 echo "VERSION_DEB=${VERSION_DEB}"
-echo "::set-output name=jitsi_version_short::${VERSION_SHORT}"
-echo "::set-output name=jitsi_version_full::${VERSION_FULL}"
-echo "::set-output name=jitsi_version_deb::${VERSION_DEB}"
+echo "jitsi_version_short=${VERSION_SHORT}" >> $GITHUB_OUTPUT
+echo "jitsi_version_full=${VERSION_FULL}" >> $GITHUB_OUTPUT
+echo "jitsi_version_deb=${VERSION_DEB}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Starting 1st June 2023 (planned) workflows, `::set-output name...::` syntax cannot be used. You can see the example warnings here: https://github.com/jitsi/jitsi/actions/runs/3678027018

ref. [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR fixes the issue by using the `GITHUB_OUTPUT` environment variable as instructed in the above article.
