### PR TITLE
Fixed HyperSQL DataBase vulnerable to remote code execution when processing untrusted input 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency><groupId>org.hsqldb</groupId><artifactId>hsqldb</artifactId><version>2.5.2</version></dependency>
+      <dependency><groupId>org.hsqldb</groupId><artifactId>hsqldb</artifactId><version>2.7.1</version></dependency>
       <dependency>
         <groupId>org.jitsi</groupId>
         <artifactId>ice4j</artifactId>


### PR DESCRIPTION
Those using java.sql.Statement or java.sql.PreparedStatement in hsqldb (HyperSQL DataBase) to process untrusted input may be vulnerable to a remote code execution attack. By default it is allowed to call any static method of any Java class in the classpath resulting in code execution. The issue can be prevented by updating to 2.7.1 or by setting the system property "hsqldb.method_class_names" to classes which are allowed to be called. For example, System.setProperty("hsqldb.method_class_names", "abc") or Java argument -Dhsqldb.method_class_names="abc" can be used. From version 2.7.1 all classes by default are not accessible except those in java.lang.Math and need to be manually enabled.


CVE-2022-41853
[CWE-470](https://cwe.mitre.org/data/definitions/470.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`