### PR TITLE
Insufficient Key Size Used

### DIFF
--- a/modules/plugin/otr/src/main/java/net/java/sip/communicator/plugin/otr/ScOtrKeyManagerImpl.java
+++ b/modules/plugin/otr/src/main/java/net/java/sip/communicator/plugin/otr/ScOtrKeyManagerImpl.java
@@ -290,7 +290,7 @@ public class ScOtrKeyManagerImpl
         try
         {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DSA");
-            keyGen.initialize(1024);
+            keyGen.initialize(2048);
             keyPair = keyGen.generateKeyPair();
         }
         catch (NoSuchAlgorithmException e)


### PR DESCRIPTION
Insufficient Key Size used while generating the DSA keypair in ScOtrKeyManagerImpl

The method generateKeyPair() in ScOtrKeyManagerImpl.java uses a cryptographic signature algorithm DSA with an insufficient key size of 1024, making a brute-force attack on the signature more feasible. As per NIST SP 800-131A guidelines, the minimum acceptable key size for the Digital Signature Generation is 2048

##Supporting Material/References:
https://rules.sonarsource.com/java/RSPEC-4426
https://cwe.mitre.org/data/definitions/326.html
https://vulncat.fortify.com/en/detail?id=desc.structural.cpp.weak_cryptographic_signature_insufficient_key_size https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf