### PR TITLE
fix misleading comment

### DIFF
--- a/modules/impl/protocol-jabber/src/test/java/TestOperationSetMultiUserChat2.java
+++ b/modules/impl/protocol-jabber/src/test/java/TestOperationSetMultiUserChat2.java
@@ -1577,7 +1577,7 @@ public class TestOperationSetMultiUserChat2
         MUCEventCollector roomUser2Col = new MUCEventCollector(
             roomUser2, MUCEventCollector.EVENT_ROLE);
 
-        // User2 (moderator role) revokes voice right to user2 (guest):
+        // User2 (moderator role) revokes voice right to user3 (guest):
         roomUser2.revokeVoice(fixture.userID3);
 
         roomUser1Col.waitForEvent(10000);


### PR DESCRIPTION
This PR removes a misleading comment (i.e. a comment that incorrectly describes what the code does).