### PR TITLE
remove obvious comment

### DIFF
--- a/modules/impl/protocol-sip/src/main/java/net/java/sip/communicator/impl/protocol/sip/EventPackageNotifier.java
+++ b/modules/impl/protocol-sip/src/main/java/net/java/sip/communicator/impl/protocol/sip/EventPackageNotifier.java
@@ -562,7 +562,6 @@ public abstract class EventPackageNotifier
                     return false;
                 }
 
-                // add the expire header
                 try
                 {
                     expHeader = protocolProvider.getHeaderFactory()


### PR DESCRIPTION
This PR removes an obvious comment (i.e. comment that restates what the code does in an obvious manner). The code itself is understandable that the expire header is added.