### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/deploy-debian.yml
+++ b/.github/workflows/deploy-debian.yml
@@ -30,7 +30,7 @@ jobs:
     concurrency: ${{ github.event.inputs.release_type || inputs.release_type }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # v1.12
       - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -32,12 +32,12 @@ jobs:
       jitsi_version_deb: ${{ steps.parse.outputs.jitsi_version_deb }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
           distribution: temurin
@@ -45,7 +45,7 @@ jobs:
       # don't use the setup-java cache option as this only caches what is
       # necessary for the version, not the other jobs
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-version-${{ hashFiles('**/pom.xml') }}
@@ -63,10 +63,10 @@ jobs:
       - version
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
           distribution: temurin
@@ -76,7 +76,7 @@ jobs:
         run: mvn -B compile
 
       - name: Upload JNI headers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: javah
           path: target/native
@@ -111,19 +111,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           #for gbp dch
           fetch-depth: 0
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: javah
           path: target/native
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
           distribution: temurin
@@ -144,7 +144,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Cache sbuild chroot stanza
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         id: chroot_cache
         with:
           path: target/chroot
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload packages and/or build logs as artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.dist.vendor }}-${{ matrix.dist.dist }}-${{ matrix.arch }}
           path: target/debian/${{ matrix.dist.dist }}/*
@@ -203,10 +203,10 @@ jobs:
           - { actions: x64, cmake: x64, cmake_opposite_arch: Win32, java: "x86-64" }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Private SDK Download
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: jitsi/jitsi-3rdparty-nonredist
           ssh-key: ${{ secrets.PRIVATE_SDK_KEY }}
@@ -214,7 +214,7 @@ jobs:
 
       - name: Set up Java
         id: install_java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: temurin
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
@@ -226,7 +226,7 @@ jobs:
         run: mvn -B -DskipTests -Drevision=${{ needs.version.outputs.jitsi_version_full }} package
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.gradle/caches
@@ -273,14 +273,14 @@ jobs:
 
       - name: Upload Debug logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: win-${{ matrix.arch.actions }}-debug
           path: debug*
 
       - name: Set up Java
         id: install_java_x64
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
           architecture: x64
@@ -295,7 +295,7 @@ jobs:
           ./gradlew --no-daemon --stacktrace windowsZip signMsi -Papplication.target=${{ matrix.arch.java }} -Pversion=${{ needs.version.outputs.jitsi_version_full }} -PgitVersion=${{ needs.version.outputs.jitsi_version_git }}
 
       - name: Upload msi
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: jitsi-win-${{ matrix.arch.actions }}
           path: |
@@ -315,17 +315,17 @@ jobs:
           #- aarch64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Get JNI headers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: javah
           path: target/native
 
       - name: Set up Java (${{ matrix.arch }})
         id: install_java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
           distribution: temurin
@@ -335,7 +335,7 @@ jobs:
         run: resources/mac-cmake.sh ${{ steps.install_java.outputs.path }} ${{ matrix.arch }}
 
       - name: Set up Java (Host)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ env.INSTALLER_JAVA_VERSION }}
           distribution: temurin
@@ -345,7 +345,7 @@ jobs:
         run: mvn -B -DskipTests -Drevision=${{ needs.version.outputs.jitsi_version_full }} package
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.gradle/caches
@@ -363,7 +363,7 @@ jobs:
           ./gradlew --no-daemon createDmg -Pversion=${{ needs.version.outputs.jitsi_version_full }} -PgitVersion=${{ needs.version.outputs.jitsi_version_git }}
 
       - name: Upload dmg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: jitsi-mac-${{ matrix.arch }}
           path: resources/install/build/install/jitsi-*-mac-*.dmg
@@ -378,10 +378,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: target
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -21,10 +21,10 @@ jobs:
         java: [ 11, 17, 21 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).