### PR TITLE
fix(security): business logic flaw: toctou bypass in otr fingerprint verification [MEDIUM]

### DIFF
--- a/modules/plugin/otr/src/main/java/net/java/sip/communicator/plugin/otr/authdialog/OtrBuddyAuthenticationDialog.java
+++ b/modules/plugin/otr/src/main/java/net/java/sip/communicator/plugin/otr/authdialog/OtrBuddyAuthenticationDialog.java
@@ -38,6 +38,7 @@ public class OtrBuddyAuthenticationDialog
     extends SIPCommDialog
 {
     private final OtrContact contact;
+    private final String storedFingerprint;
 
     /**
      * The {@link OtrBuddyAuthenticationDialog} ctor.
@@ -49,6 +50,9 @@ public class OtrBuddyAuthenticationDialog
     {
         super(false);
         this.contact = contact;
+        this.storedFingerprint =
+            OtrActivator.scOtrKeyManager.getFingerprintFromPublicKey(
+                OtrActivator.scOtrEngine.getRemotePublicKey(contact));
 
         initComponents();
     }
@@ -191,20 +195,15 @@ public class OtrBuddyAuthenticationDialog
                     ActionComboBoxItem actionItem =
                         (ActionComboBoxItem) fingerprintPanel.
                             getCbAction().getSelectedItem();
-                    PublicKey pubKey =
-                        OtrActivator.scOtrEngine.getRemotePublicKey(contact);
-                    String fingerprint =
-                        OtrActivator.scOtrKeyManager.
-                            getFingerprintFromPublicKey(pubKey);
                     switch (actionItem.action)
                     {
                     case I_HAVE:
                         OtrActivator.scOtrKeyManager.verify(
-                            contact, fingerprint);
+                            contact, storedFingerprint);
                         break;
                     case I_HAVE_NOT:
                         OtrActivator.scOtrKeyManager.unverify(
-                            contact, fingerprint);
+                            contact, storedFingerprint);
                         break;
                     }
                     dispose();


### PR DESCRIPTION
### Security Finding: Business Logic Flaw: TOCTOU Bypass in OTR Fingerprint Verification

**Severity:** MEDIUM
**Reported by:** FailSafe Research Team
**Component:** `modules/plugin/otr/src/main/java/net/java/sip/communicator/plugin/otr/authdialog/OtrBuddyAuthenticationDialog.java:194`

### Description

Step 1: A user initiates an out-of-band verification process and opens the OTR Authentication dialog. The `FingerprintAuthenticationPanel` fetches and displays the remote user's current public key fingerprint. 
Step 2: While the dialog remains open and the user is manually verifying the fingerprint, a network attacker intercepts the connection and forces a new OTR session, injecting a malicious public key. 
Step 3: The user finishes verifying the original fingerprint and clicks the 'Authenticate Buddy' button. 
Step 4: The `OtrBuddyAuthenticationDialog` business logic re-fetches the remote public key from the OTR engine (`getRemotePublicKey`) instead of using the fingerprint that was actually displayed to the user. The system verifies the attacker's new key, bypassing the user's manual authorization check.

```
 189                    else if (authenticationMethod.equals(am[2]))
 190                    {
 191                        ActionComboBoxItem actionItem =
 192                            (ActionComboBoxItem) fingerprintPanel.
 193                                getCbAction().getSelectedItem();
 194>>>                     PublicKey pubKey =
 195                            OtrActivator.scOtrEngine.getRemotePublicKey(contact);
 196                        String fingerprint =
 197                            OtrActivator.scOtrKeyManager.
 198                                getFingerprintFromPublicKey(pubKey);
 199                        switch (actionItem.action)
```

### Fix

Eliminate the Time-of-Check to Time-of-Use (TOCTOU) vulnerability by storing the exact fingerprint string that was displayed to the user in the dialog's state when the `FingerprintAuthenticationPanel` is initialized. When the user clicks the 'Authenticate Buddy' button, retrieve this stored fingerprint and pass it directly to `OtrActivator.scOtrKeyManager.verify(contact, storedFingerprint)`. Do not re-fetch the current key from the OTR engine during the verification action. This ensures that the system only authorizes the exact cryptographic identity that the user visually inspected.

### Test Plan

1. Analyze the Time-of-Check to Time-of-Use (TOCTOU) condition. The 'Check' occurs when the user visually verifies the fingerprint displayed in the UI. The 'Use' occurs when the user clicks 'Authenticate Buddy'.
2. Observe the state gap. The vulnerability exists because the application re-fetches the current key from the OTR engine (`OtrActivator.scOtrEngine.getRemotePublicKey(contact)`) during the 'Use' phase, rather than using the key that was verified during the 'Check' phase.
3. To remediate this flaw, the application architecture must be updated to eliminate the TOCTOU gap. The `FingerprintAuthenticationPanel` should pass the specific `PublicKey` object or fingerprint string that was displayed to the user directly to the authentication handler.
4. Replace the vulnerable code at line 194 to use the cached, verified key instead of querying the engine again. For example: `PublicKey pubKey = this.displayedAndVerifiedPublicKey;`