### PR TITLE
ci: SHA-pin actions and harden workflow permissions

### DIFF
--- a/.github/workflows/deploy-debian.yml
+++ b/.github/workflows/deploy-debian.yml
@@ -22,6 +22,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: to ${{ github.event.inputs.release_type || inputs.release_type }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   version:
     name: Versioning
@@ -236,7 +239,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: Build natives
         env:
@@ -355,7 +358,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: Generate dmg
         run: |
@@ -376,6 +379,8 @@ jobs:
       - wix
       - mac
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   java:
     name: Build with Java ${{ matrix.java }}


### PR DESCRIPTION
## What

Two complementary supply-chain hardening changes to `.github/workflows/`:

1. **SHA-pin the last unpinned external action.** Most actions in this repo were already pinned. This patch finishes the job by pinning `gradle/actions/wrapper-validation@v4` (used in `installers.yml`).
2. **Explicit `permissions:` on every workflow.** Default `contents: read` at the top; the `release` job in `installers.yml` gets `contents: write` per-job for `ncipollo/release-action`.

## Why

### Pinning
A tag like `@v4` is mutable — the upstream maintainer can move it, and a hostile maintainer (or an attacker who's compromised the maintainer's account) can replace it with attacker code. The next CI run after that move executes the new code with whatever secrets the workflow holds.

Real precedents from 2025: CVE-2025-30066 (`tj-actions/changed-files`), CVE-2025-30067 (`reviewdog/action-setup`).

SHA-pinning resolves `@v4` once, today, and freezes the workflow at that exact commit. Future tag moves can't affect us. The trailing `# v4` comment preserves the human-readable version so a reader (or Dependabot auto-bumper) knows what version is pinned.

### Permissions hardening
SHA-pinning protects the entry point. It does not protect against:
- The action invoking sub-actions or fetching code at runtime.
- A compromise of the action's maintainer reaching into actions we transitively depend on.

`permissions:` caps the GITHUB_TOKEN's authority so even a fully compromised action can only do what we explicitly granted.

Per-job grants:
- `installers.yml` → `release` job: `contents: write` (ncipollo/release-action creates GitHub releases)
- All other jobs default to `contents: read`.

## Detected by

SOCmate's `gha_audit` workflow + `gha_pinning_findings` table flagged this repo (1 high-severity finding).

## Notes for review

- I did not bump action versions; only the unpinned `gradle/actions/wrapper-validation@v4` was changed (now pinned to its current SHA).
- For per-job permissions I matched the action's documented requirements; please scrutinize the `release` job if it fails — that means I under-granted.
- This PR is draft: please run CI before marking ready.

## Test plan

- [ ] All workflows trigger as expected (push/PR/workflow_call/workflow_dispatch).
- [ ] No "permission denied" errors from any action; specifically the `release` job in `installers.yml` should still create/update a draft release.
- [ ] Re-run SOCmate's `gha pinning` audit after merge — this repo's high-severity count should drop to zero.
