### PR TITLE
chore: fix broken annotated-tag-object pins (workflow not found)

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -239,7 +239,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
       - name: Build natives
         env:
@@ -358,7 +358,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
+        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
       - name: Generate dmg
         run: |


### PR DESCRIPTION
Hotfix follow-up — repo-wide audit triggered by 8x8/unified-analytics-orion#801 build failures revealed pins set to annotated-tag-object SHAs that GHA cannot resolve as uses: refs.

Each replacement SHA is the dereferenced commit from gh api repos/<owner>/<name>/git/tags/<tag-object-sha> .object.sha — same content, just the right kind of SHA for uses:.

## Test plan
- [ ] CI passes on this branch (no 'workflow not found' errors)