### PR TITLE
Skip deb package signing on PR builds; use rm -f for man-db auto-update removal

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -135,11 +135,12 @@ jobs:
       - name: Install tools
         run: |
           # No need for updated man pages on GitHub
-          sudo rm /var/lib/man-db/auto-update
+          sudo rm -f /var/lib/man-db/auto-update
           resources/deb-prepare.sh
           sudo ln -s ~/.m2/repository /var/cache/m2-sbuild
 
       - name: Import GPG key
+        if: github.ref == 'refs/heads/master'
         env:
           GPG_PASSPHRASE: "${{ secrets.GPG_PW }}"
         run: |
@@ -175,7 +176,7 @@ jobs:
             "${{ needs.version.outputs.jitsi_version_deb }}" \
             "${{ matrix.dist.dist }}" \
             "${{ matrix.arch }}" \
-            "dev+maven@jitsi.org"
+            "${{ github.ref == 'refs/heads/master' && 'dev+maven@jitsi.org' || '' }}"
 
       - name: make build files readable for Windows and archivable for GitHub Actions
         if: ${{ always() }}

--- a/resources/deb-build.sh
+++ b/resources/deb-build.sh
@@ -81,7 +81,9 @@ else
   cp "${PROJECT_DIR}"/../jitsi_* "$BUILD_DIR"
 fi
 
-debsign -S -e"${GPG_ID}" "${BUILD_DIR}"/*.changes --re-sign -p"${PROJECT_DIR}"/resources/gpg-wrap.sh
+if [[ -n "${GPG_ID}" ]]; then
+  debsign -S -e"${GPG_ID}" "${BUILD_DIR}"/*.changes --re-sign -p"${PROJECT_DIR}"/resources/gpg-wrap.sh
+fi
 
 #make build files readable for Windows and archivable for GitHub Actions
 rename 's|:|-|g' "$BUILD_DIR"/*.build


### PR DESCRIPTION
Secrets (GPG_KEY, GPG_PW) aren't available on PRs from forks, causing the GPG import step to fail with "no valid OpenPGP data found". Guard the import on master only and skip debsign when no GPG ID is provided so PRs still validate the deb build.

The man-db auto-update file no longer exists on current GitHub runner images, so the unconditional rm fails the build. Use -f so the step is idempotent across runner image versions.