### PR TITLE
test: make mvn test/verify pass on non-OSGi build

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Build Java source with Maven
         run: |
-          mvn -B verify -DperformRelease=true -DskipTests
+          mvn -B verify -DperformRelease=true

--- a/modules/service/netaddr/src/test/java/Win32LocalhostTest.java
+++ b/modules/service/netaddr/src/test/java/Win32LocalhostTest.java
@@ -17,6 +17,7 @@
  */
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 import java.io.*;
 import java.net.*;
@@ -28,6 +29,8 @@ public class Win32LocalhostTest
     @Test
     public void testBestAdapterRoute() throws IOException
     {
+        assumeTrue("Win32-specific test, skipping on non-Windows",
+            System.getProperty("os.name", "").toLowerCase().startsWith("windows"));
         InetAddress localhost = Win32LocalhostRetriever
             .getSourceForDestination(InetAddress.getLoopbackAddress());
         assertEquals(InetAddress.getLoopbackAddress(), localhost);

--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,50 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.3</version>
+        <configuration>
+          <!--
+            Several modules ship OSGi LICK/Slick-style integration tests
+            (paired with *Lick.java / *SlickFixture.java). Their
+            BundleContext is only populated when the bundle is started
+            inside an OSGi runtime; there is no OSGi container wired up
+            for the Maven build, so running them via plain Surefire NPEs
+            in setUp/constructor. Exclude them globally until an
+            OSGi-based test runner is reintroduced.
+          -->
+          <excludes>
+            <exclude>TestAccountInstallation.java</exclude>
+            <exclude>TestAccountUninstallation.java</exclude>
+            <exclude>TestAccountUninstallationPersistence.java</exclude>
+            <exclude>TestAutoProxyDetection.java</exclude>
+            <exclude>TestCallHistoryService.java</exclude>
+            <exclude>TestCredentialsStorageService.java</exclude>
+            <exclude>TestHistoryService.java</exclude>
+            <exclude>TestMetaContact.java</exclude>
+            <exclude>TestMetaContactGroup.java</exclude>
+            <exclude>TestMetaContactList.java</exclude>
+            <exclude>TestMetaContactListPersistence.java</exclude>
+            <exclude>TestMetaHistoryService.java</exclude>
+            <exclude>TestMsgHistoryService.java</exclude>
+            <exclude>TestMsgHistoryServiceMultiChat.java</exclude>
+            <exclude>TestOperationSetBasicInstantMessaging.java</exclude>
+            <exclude>TestOperationSetBasicTelephonyJabberImpl.java</exclude>
+            <exclude>TestOperationSetBasicTelephonySipImpl.java</exclude>
+            <exclude>TestOperationSetFileTransferImpl.java</exclude>
+            <exclude>TestOperationSetInstantMessageTransformJabberImpl.java</exclude>
+            <exclude>TestOperationSetMultiUserChat.java</exclude>
+            <exclude>TestOperationSetMultiUserChat2.java</exclude>
+            <exclude>TestOperationSetPersistentPresence.java</exclude>
+            <exclude>TestOperationSetPresence.java</exclude>
+            <exclude>TestOperationSetServerStoredInfo.java</exclude>
+            <exclude>TestOperationSetServerStoredInfoData.java</exclude>
+            <exclude>TestOperationSetTypingNotifications.java</exclude>
+            <exclude>TestProtocolProviderServiceGibberishImpl.java</exclude>
+            <exclude>TestProtocolProviderServiceJabberImpl.java</exclude>
+            <exclude>TestProtocolProviderServiceSipImpl.java</exclude>
+            <exclude>TestSupportForMultipleProviders.java</exclude>
+            <exclude>TestXCapParse.java</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Win32LocalhostTest now skips on non-Windows via Assume rather than failing on the missing IPHlpAPI native library.

Globally exclude OSGi LICK/Slick-style integration tests from Surefire in the parent pom. They require a BundleContext that is only populated when the test bundle is started inside an OSGi runtime, which is not wired up for the Maven build. Drop -DskipTests from CI now that the remaining unit tests run cleanly.