### PR TITLE
chore: hotfix gradle/actions/wrapper-validation tag-object SHA pin

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -243,7 +243,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - name: Build natives
         env:
@@ -362,7 +362,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Verify Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - name: Generate dmg
         run: |


### PR DESCRIPTION
## Summary

Hotfix follow-up to merged #842. The SHA `48b5f213c81028ace310571dc5ec0fbbca0b2947` was supposed to be the commit SHA for `gradle/actions@v4`, but it is actually the **annotated-tag-object SHA**. GitHub Actions cannot resolve tag-object SHAs as `uses:` refs and fails at workflow load with "workflow not found" / "unable to find version" — the same incident class as `unified-analytics-orion#801`.

Replacing with the dereferenced commit SHA `ed408507eac070d1f99cc633dbcf757c94c7933a` (both occurrences in `installers.yml`).

## Verification

```
$ gh api repos/gradle/actions/git/tags/48b5f213c81028ace310571dc5ec0fbbca0b2947 --jq '.object'
{"sha":"ed408507eac070d1f99cc633dbcf757c94c7933a","type":"commit"}

$ gh api repos/gradle/actions/commits/v4 --jq '.sha'
ed408507eac070d1f99cc633dbcf757c94c7933a
```

`scripts/verify-gha-pins.sh .github/workflows` exits 0 with the fix applied.

## Test plan

- [ ] CI passes on this branch (workflow loads without "workflow not found")
- [ ] After merge, the next PR that triggers `installers.yml` runs `wrapper-validation` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)