### PR TITLE
Upgrade to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.0</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <compilerArgs>
             <arg>-Xlint:all,-serial</arg>
             <arg>-h</arg>


### PR DESCRIPTION
Upgrades the build from Java 11 to Java 17 (LTS).

- `pom.xml`: `maven-compiler-plugin` `<release>` 11 → 17

**Verification:** the project compiles under JDK 17 and all 226 tests pass, with none lost versus the JDK-11 baseline. No production or test code was changed — only the compiler target.



---
### How this was produced
The compiler-target change was produced with OpenRewrite's `UpgradeJavaVersion` recipe:

```yaml
# rewrite.yml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.UpgradeJava
recipeList:
  - org.openrewrite.java.migrate.UpgradeJavaVersion:
      version: 17
```
```bash
mvn -U org.openrewrite.maven:rewrite-maven-plugin:RELEASE:run \
  -Drewrite.configLocation=$(pwd)/rewrite.yml \
  -Drewrite.activeRecipes=com.example.UpgradeJava \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE
```
The diff was then reduced by hand to the minimal compiler-target change.

_Verified: all 226 tests pass under JDK 17, none lost versus the baseline._
